### PR TITLE
Adding pagination to Gitlab.getProjects

### DIFF
--- a/gitlab/__init__.py
+++ b/gitlab/__init__.py
@@ -212,13 +212,14 @@ class Gitlab(object):
         else:
             return True
 
-    def getProjects(self):
+    def getProjects(self, page=1, per_page=20):
         """
         Returns a dictionary of all the projects
         :return: list with the repo name, description, last activity,
          web url, ssh url, owner and if its public
         """
-        request = requests.get(self.projects_url, headers=self.headers)
+        params = {'page': page, 'per_page': per_page}
+        request = requests.get(self.projects_url, params=params, headers=self.headers)
         if request.status_code == 200:
             return json.loads(request.content)
         else:


### PR DESCRIPTION
It doesn't currently exist.  I ran into a wall head long and it took a while to debug and figure out the cause.  I thought returning only `20` projects was too perfect of a number and it turns out it was.  The [API](http://api.gitlab.org/) supports pagination so I'm adding it to your `getProjects` call.
