### PR TITLE
Make python-gitlab compatible with Python3

### DIFF
--- a/gitlab/__init__.py
+++ b/gitlab/__init__.py
@@ -48,7 +48,7 @@ class Gitlab(object):
             self.headers = {"PRIVATE-TOKEN": self.token}
             return True
         else:
-            print request
+            print(request)
             return False
 
     def getusers(self, id_=0, page=1, per_page=20, sudo=""):
@@ -110,7 +110,7 @@ class Gitlab(object):
         if request.status_code == 201:
             return True
         elif request.status_code == 404:
-            print request
+            print(request)
             return False
 
     def deleteuser(self, id_):
@@ -126,7 +126,7 @@ class Gitlab(object):
         if request.status_code == 200:
             return True
         else:
-            print request
+            print(request)
             return False
 
     def currentuser(self):
@@ -216,7 +216,7 @@ class Gitlab(object):
         if request.status_code == 200:
             return json.loads(request.content)
         else:
-            print request
+            print(request)
             return False
 
     def getsshkey(self, id_):
@@ -230,7 +230,7 @@ class Gitlab(object):
         if request.status_code == 200:
             return json.loads(request.content)
         else:
-            print request
+            print(request)
             return False
 
     def addsshkey(self, title, key, sudo=""):
@@ -248,7 +248,7 @@ class Gitlab(object):
         if request.status_code == 201:
             return True
         else:
-            print request
+            print(request)
             return False
 
     def addsshkeyuser(self, id_, title, key, sudo=""):
@@ -268,7 +268,7 @@ class Gitlab(object):
         if request.status_code == 201:
             return True
         else:
-            print request
+            print(request)
             return False
 
     def deletesshkey(self, id_):
@@ -280,7 +280,7 @@ class Gitlab(object):
         request = requests.delete(self.keys_url + "/" + str(id_),
                                   headers=self.headers)
         if request.content == "null":
-            print request
+            print(request)
             return False
         else:
             return True
@@ -301,7 +301,7 @@ class Gitlab(object):
         if request.status_code == 200:
             return json.loads(request.content)
         else:
-            print request
+            print(request)
             return False
 
     def getproject(self, id_):
@@ -315,7 +315,7 @@ class Gitlab(object):
         if request.status_code == 200:
             return json.loads(request.content)
         else:
-            print request
+            print(request)
             return False
 
     def getprojectevents(self, id_, page=1, per_page=20):
@@ -333,7 +333,7 @@ class Gitlab(object):
         if request.status_code == 200:
             return json.loads(request.content)
         else:
-            print request
+            print(request)
             return False
 
     def createproject(self, name, description="", default_branch="",
@@ -364,7 +364,7 @@ class Gitlab(object):
         if request.status_code == 201:
             return json.loads(request.content)
         else:
-            print request
+            print(request)
             return False
 
     def createprojectuser(self, id_, name, description="", default_branch="",
@@ -390,7 +390,7 @@ class Gitlab(object):
         if request.status_code == 201:
             return True
         else:
-            print request
+            print(request)
             return False
 
     def listprojectmembers(self, id_):
@@ -404,7 +404,7 @@ class Gitlab(object):
         if request.status_code == 200:
             return json.loads(request.content)
         else:
-            print request
+            print(request)
             return False
 
     def addprojectmember(self, id_, user_id, access_level, sudo=""):
@@ -434,7 +434,7 @@ class Gitlab(object):
         if request.status_code == 201:
             return True
         else:
-            print request
+            print(request)
             return False
 
     def editprojectmember(self, id_, user_id, access_level, sudo=""):
@@ -464,7 +464,7 @@ class Gitlab(object):
         if request.status_code == 200:
             return True
         else:
-            print request
+            print(request)
             return False
 
     def deleteprojectmember(self, id_, user_id):
@@ -491,7 +491,7 @@ class Gitlab(object):
         if request.status_code == 200:
             return json.loads(request.content)
         else:
-            print request
+            print(request)
             return False
 
     def getprojecthook(self, id_, hook_id):
@@ -506,7 +506,7 @@ class Gitlab(object):
         if request.status_code == 200:
             return json.loads(request.content)
         else:
-            print request
+            print(request)
             return False
 
     def addprojecthook(self, id_, url):
@@ -522,7 +522,7 @@ class Gitlab(object):
         if request.status_code == 201:
             return True
         else:
-            print request
+            print(request)
             return False
 
     def editprojecthook(self, id_, hook_id, url, sudo=""):
@@ -543,7 +543,7 @@ class Gitlab(object):
         if request.status_code == 200:
             return True
         else:
-            print request
+            print(request)
             return False
 
     def deleteprojecthook(self, id_, hook_id):
@@ -559,7 +559,7 @@ class Gitlab(object):
         if request.status_code == 200:
             return True
         else:
-            print request
+            print(request)
             return False
 
     def listbranches(self, id_):
@@ -573,7 +573,7 @@ class Gitlab(object):
         if request.status_code == 200:
             return json.loads(request.content)
         else:
-            print request
+            print(request)
             return False
 
     def listbranch(self, id_, branch):
@@ -589,7 +589,7 @@ class Gitlab(object):
         if request.status_code == 200:
             return json.loads(request.content)
         else:
-            print request
+            print(request)
             return False
 
     def protectbranch(self, id_, branch):
@@ -606,7 +606,7 @@ class Gitlab(object):
         if request.status_code == 200:
             return True
         else:
-            print request
+            print(request)
             return False
 
     def unprotectbranch(self, id_, branch):
@@ -623,7 +623,7 @@ class Gitlab(object):
         if request.status_code == 200:
             return True
         else:
-            print request
+            print(request)
             return False
 
     def createforkrelation(self, id_, from_):
@@ -641,7 +641,7 @@ class Gitlab(object):
         if request.status_code == 201:
             return True
         else:
-            print request
+            print(request)
             return False
 
     def removeforkrelation(self, id_):
@@ -656,7 +656,7 @@ class Gitlab(object):
         if request.status_code == 200:
             return True
         else:
-            print request
+            print(request)
             return False
 
     def getissues(self, page=1, per_page=20, sudo=""):
@@ -673,7 +673,7 @@ class Gitlab(object):
         if request.status_code == 200:
             return json.loads(request.content)
         else:
-            print request
+            print(request)
             return False
 
     def getprojectissues(self, id_, page=1, per_page=20, sudo=""):
@@ -691,7 +691,7 @@ class Gitlab(object):
         if request.status_code == 200:
             return json.loads(request.content)
         else:
-            print request
+            print(request)
             return False
 
     def getprojectissue(self, id_, issue_id):
@@ -706,7 +706,7 @@ class Gitlab(object):
         if request.status_code == 200:
             return json.loads(request.content)
         else:
-            print request
+            print(request)
             return False
 
     def createissue(self, id_, title, description="", assignee_id="",
@@ -732,7 +732,7 @@ class Gitlab(object):
         if request.status_code == 201:
             return True
         else:
-            print request
+            print(request)
             return False
 
     def editissue(self, id_, issue_id, title="", description="",
@@ -763,7 +763,7 @@ class Gitlab(object):
         if request.status_code == 201:
             return True
         else:
-            print request
+            print(request)
             return False
 
     def getmilestones(self, id_):
@@ -777,7 +777,7 @@ class Gitlab(object):
         if request.status_code == 200:
             return json.loads(request.content)
         else:
-            print request
+            print(request)
             return False
 
     def getmilestone(self, id_, milestone_id):
@@ -793,7 +793,7 @@ class Gitlab(object):
         if request.status_code == 200:
             return json.loads(request.content)
         else:
-            print request
+            print(request)
             return False
 
     def createmilestone(self, id_, title, description="", due_date="", sudo=""):
@@ -815,7 +815,7 @@ class Gitlab(object):
         if request.status_code == 201:
             return True
         else:
-            print request
+            print(request)
             return False
 
     def editmilestone(self, id_, milestone_id, title="", description="",
@@ -843,7 +843,7 @@ class Gitlab(object):
         if request.status_code == 200:
             return True
         else:
-            print request
+            print(request)
             return False
 
     def listdeploykeys(self, id_):
@@ -857,7 +857,7 @@ class Gitlab(object):
         if request.status_code == 200:
             return json.loads(request.content)
         else:
-            print request
+            print(request)
             return False
 
     def listdeploykey(self, id_, key_id):
@@ -872,7 +872,7 @@ class Gitlab(object):
         if request.status_code == 200:
             return json.loads(request.content)
         else:
-            print request
+            print(request)
             return False
 
     def adddeploykey(self, id_, title, key, sudo=""):
@@ -893,7 +893,7 @@ class Gitlab(object):
         if request.status_code == 201:
             return True
         else:
-            print request
+            print(request)
             return False
 
     def deletedeploykey(self, id_, key_id):
@@ -908,7 +908,7 @@ class Gitlab(object):
         if request.status_code == 200:
             return True
         else:
-            print request
+            print(request)
             return False
 
     def getreadme(self, repo, mark=False):
@@ -943,7 +943,7 @@ class Gitlab(object):
         if request.status_code == 201:
             return True
         else:
-            print request
+            print(request)
             return False
 
     def getgroups(self, id_=None, page=1, per_page=20, sudo=""):
@@ -962,7 +962,7 @@ class Gitlab(object):
         if request.status_code == 200:
             return json.loads(request.content)
         else:
-            print request
+            print(request)
             return False
 
     def moveproject(self, group_id, project_id):
@@ -978,7 +978,7 @@ class Gitlab(object):
         if request.status_code == 201:
             return True
         else:
-            print request
+            print(request)
             return False
 
     def getmergerequests(self, project_id, page=None, per_page=None, sudo=""):
@@ -997,7 +997,7 @@ class Gitlab(object):
         if request.status_code == 200:
             return json.loads(request.content)
         else:
-            print request
+            print(request)
             return False
 
     def getmergerequest(self, project_id, mergerequest_id):
@@ -1015,7 +1015,7 @@ class Gitlab(object):
         if request.status_code == 200:
             return json.loads(request.content)
         else:
-            print request
+            print(request)
             return False
 
     def createmergerequest(self, project_id, sourcebranch, targetbranch,
@@ -1040,7 +1040,7 @@ class Gitlab(object):
         if request.status_code == 201:
             return True
         else:
-            print request
+            print(request)
             return False
 
     def updatemergerequest(self, project_id, mergerequest_id, sourcebranch=None,
@@ -1072,7 +1072,7 @@ class Gitlab(object):
         if request.status_code == 201:
             return True
         else:
-            print request
+            print(request)
             return False
 
     def addcommenttomergerequest(self, project_id, mergerequest_id, note):
@@ -1091,5 +1091,5 @@ class Gitlab(object):
         if request.status_code == 201:
             return True
         else:
-            print request
+            print(request)
             return False


### PR DESCRIPTION
This pull request makes gitlab module compatible with Python3. `2to3` tool was used for this purpose and it only replaced `python request` with `python(request)`. Modules used in gitlab module are already ported to Python 3. BTW: print() method was back-ported to Python 2.6 and Python 2.7 (may be other). Thus it could be used in Python 2.x too.
