### PR TITLE
Fixes user not required during init, closes #44

### DIFF
--- a/gitlab/__init__.py
+++ b/gitlab/__init__.py
@@ -13,11 +13,10 @@ class Gitlab(object):
     """
     Gitlab class
     """
-    def __init__(self, host, user, token=""):
+    def __init__(self, host, token=""):
         """
         on init we setup the token used for all the api calls and all the urls
         :param host: host of gitlab
-        :param user: user
         :param token: token
         """
         if token != "":
@@ -31,7 +30,6 @@ class Gitlab(object):
         self.users_url = self.host + "/api/v3/users"
         self.keys_url = self.host + "/api/v3/user/keys"
         self.groups_url = self.host + "/api/v3/groups"
-        self.user = user
 
     def login(self, user, password):
         """

--- a/gitlab/__init__.py
+++ b/gitlab/__init__.py
@@ -38,7 +38,6 @@ class Gitlab(object):
         :param password: gitlab password
         :return: True if login successfull
         """
-        self.user = user
         data = {"email": user, "password": password}
         request = requests.post(self.host + "/api/v3/session", data=data)
         if request.status_code == 201:


### PR DESCRIPTION
This fixes a bug when gitlab.Gitlab(host,token) unnecessarily
requires a `user` arg but it is not required.

I have tested this on my GitLab 6.2.3 instance and it works.

SAM
