### PR TITLE
Added custom access_level attribute to Gitlab.addgroupmembers()

### DIFF
--- a/gitlab/__init__.py
+++ b/gitlab/__init__.py
@@ -48,7 +48,7 @@ class Gitlab(object):
         :return: True if login successfull
         """
         data = {"email": user, "password": password}
-        request = requests.post(self.host + "/api/v3/session", data=data, 
+        request = requests.post(self.host + "/api/v3/session", data=data,
                                 verify=self.verify_ssl,
                                 headers={"connection": "close"})
         if request.status_code == 201:
@@ -114,7 +114,7 @@ class Gitlab(object):
                 "provider": provider, "bio": bio}
         if sudo != "":
             data['sudo'] = sudo
-        request = requests.post(self.users_url, headers=self.headers, data=data, 
+        request = requests.post(self.users_url, headers=self.headers, data=data,
                                 verify=self.verify_ssl)
         if request.status_code == 201:
             return json.loads(request.content.decode("utf-8"))
@@ -134,7 +134,7 @@ class Gitlab(object):
         if request.status_code == 200:
             return True
         else:
-            
+
             return False
 
     def currentuser(self):
@@ -224,7 +224,7 @@ class Gitlab(object):
         if request.status_code == 200:
             return json.loads(request.content.decode("utf-8"))
         else:
-            
+
             return False
 
     def getsshkey(self, id_):
@@ -238,7 +238,7 @@ class Gitlab(object):
         if request.status_code == 200:
             return json.loads(request.content.decode("utf-8"))
         else:
-            
+
             return False
 
     def addsshkey(self, title, key, sudo=""):
@@ -252,12 +252,12 @@ class Gitlab(object):
         data = {"title": title, "key": key}
         if sudo != "":
             data['sudo'] = sudo
-        request = requests.post(self.keys_url, headers=self.headers, data=data, 
+        request = requests.post(self.keys_url, headers=self.headers, data=data,
                                 verify=self.verify_ssl)
         if request.status_code == 201:
             return True
         else:
-            
+
             return False
 
     def addsshkeyuser(self, id_, title, key, sudo=""):
@@ -277,7 +277,7 @@ class Gitlab(object):
         if request.status_code == 201:
             return True
         else:
-            
+
             return False
 
     def deletesshkey(self, id_):
@@ -289,7 +289,7 @@ class Gitlab(object):
         request = requests.delete(self.keys_url + "/" + str(id_),
                                   headers=self.headers)
         if request.content == "null":
-            
+
             return False
         else:
             return True
@@ -341,7 +341,7 @@ class Gitlab(object):
         if request.status_code == 200:
             return json.loads(request.content.decode("utf-8"))
         else:
-            
+
             return False
 
     def getprojectevents(self, id_, page=1, per_page=20):
@@ -355,12 +355,12 @@ class Gitlab(object):
         """
         data = {'page': page, 'per_page': per_page}
         request = requests.get(self.projects_url + "/" + str(id_) +
-                               "/events", params=data, headers=self.headers, 
+                               "/events", params=data, headers=self.headers,
                                verify=self.verify_ssl)
         if request.status_code == 200:
             return json.loads(request.content.decode("utf-8"))
         else:
-            
+
             return False
 
     def createproject(self, name, description="",
@@ -396,7 +396,7 @@ class Gitlab(object):
                 print(request.content)
                 return False
         else:
-            
+
             return False
 
     def deleteproject(self, project_id):
@@ -434,7 +434,7 @@ class Gitlab(object):
         if request.status_code == 201:
             return True
         else:
-            
+
             return False
 
     def listprojectmembers(self, id_):
@@ -448,7 +448,7 @@ class Gitlab(object):
         if request.status_code == 200:
             return json.loads(request.content.decode("utf-8"))
         else:
-            
+
             return False
 
     def addprojectmember(self, id_, user_id, access_level, sudo=""):
@@ -505,7 +505,7 @@ class Gitlab(object):
         if request.status_code == 200:
             return True
         else:
-            
+
             return False
 
     def deleteprojectmember(self, id_, user_id):
@@ -535,7 +535,7 @@ class Gitlab(object):
         if request.status_code == 200:
             return json.loads(request.content.decode("utf-8"))
         else:
-            
+
             return False
 
     def getprojecthook(self, id_, hook_id):
@@ -550,7 +550,7 @@ class Gitlab(object):
         if request.status_code == 200:
             return json.loads(request.content.decode("utf-8"))
         else:
-            
+
             return False
 
     def addprojecthook(self, id_, url):
@@ -566,7 +566,7 @@ class Gitlab(object):
         if request.status_code == 201:
             return True
         else:
-            
+
             return False
 
     def editprojecthook(self, id_, hook_id, url, sudo=""):
@@ -587,7 +587,7 @@ class Gitlab(object):
         if request.status_code == 200:
             return True
         else:
-            
+
             return False
 
     def deleteprojecthook(self, id_, hook_id):
@@ -603,7 +603,7 @@ class Gitlab(object):
         if request.status_code == 200:
             return True
         else:
-            
+
             return False
 
     def listbranches(self, id_):
@@ -633,7 +633,7 @@ class Gitlab(object):
         if request.status_code == 200:
             return json.loads(request.content.decode("utf-8"))
         else:
-            
+
             return False
 
     def protectbranch(self, id_, branch):
@@ -649,7 +649,7 @@ class Gitlab(object):
         if request.status_code == 200:
             return True
         else:
-            
+
             return False
 
     def unprotectbranch(self, id_, branch):
@@ -665,7 +665,7 @@ class Gitlab(object):
         if request.status_code == 200:
             return True
         else:
-            
+
             return False
 
     def createforkrelation(self, id_, from_):
@@ -683,7 +683,7 @@ class Gitlab(object):
         if request.status_code == 201:
             return True
         else:
-            
+
             return False
 
     def removeforkrelation(self, id_):
@@ -698,7 +698,7 @@ class Gitlab(object):
         if request.status_code == 200:
             return True
         else:
-            
+
             return False
 
     def getissues(self, page=1, per_page=20, sudo=""):
@@ -715,7 +715,7 @@ class Gitlab(object):
         if request.status_code == 200:
             return json.loads(request.content.decode("utf-8"))
         else:
-            
+
             return False
 
     def getprojectissues(self, id_, page=1, per_page=20, sudo=""):
@@ -734,7 +734,7 @@ class Gitlab(object):
         if request.status_code == 200:
             return json.loads(request.content.decode("utf-8"))
         else:
-            
+
             return False
 
     def getprojectissue(self, id_, issue_id):
@@ -745,12 +745,12 @@ class Gitlab(object):
         :return: the issue
         """
         request = requests.get(self.projects_url + "/" + str(id_) +
-                               "/issues/" + str(issue_id), headers=self.headers, 
+                               "/issues/" + str(issue_id), headers=self.headers,
                                verify=self.verify_ssl)
         if request.status_code == 200:
             return json.loads(request.content.decode("utf-8"))
         else:
-            
+
             return False
 
     def createissue(self, id_, title, description="", assignee_id="",
@@ -776,7 +776,7 @@ class Gitlab(object):
         if request.status_code == 201:
             return True
         else:
-            
+
             return False
 
     def editissue(self, id_, issue_id, title="", description="",
@@ -829,7 +829,7 @@ class Gitlab(object):
         if request.status_code == 200:
             return json.loads(request.content.decode("utf-8"))
         else:
-            
+
             return False
 
     def getmilestone(self, id_, milestone_id):
@@ -845,7 +845,7 @@ class Gitlab(object):
         if request.status_code == 200:
             return json.loads(request.content.decode("utf-8"))
         else:
-            
+
             return False
 
     def createmilestone(self, id_, title, description="", due_date="", sudo=""):
@@ -863,12 +863,12 @@ class Gitlab(object):
         if sudo != "":
             data['sudo'] = sudo
         request = requests.post(self.projects_url + "/" + str(id_) +
-                                "/milestones", headers=self.headers, data=data, 
+                                "/milestones", headers=self.headers, data=data,
                                 verify=self.verify_ssl)
         if request.status_code == 201:
             return True
         else:
-            
+
             return False
 
     def editmilestone(self, id_, milestone_id, title="", description="",
@@ -896,7 +896,7 @@ class Gitlab(object):
         if request.status_code == 200:
             return True
         else:
-            
+
             return False
 
     def listdeploykeys(self, id_):
@@ -910,7 +910,7 @@ class Gitlab(object):
         if request.status_code == 200:
             return json.loads(request.content.decode("utf-8"))
         else:
-            
+
             return False
 
     def listdeploykey(self, id_, key_id):
@@ -925,7 +925,7 @@ class Gitlab(object):
         if request.status_code == 200:
             return json.loads(request.content.decode("utf-8"))
         else:
-            
+
             return False
 
     def adddeploykey(self, id_, title, key, sudo=""):
@@ -946,7 +946,7 @@ class Gitlab(object):
         if request.status_code == 201:
             return True
         else:
-            
+
             return False
 
     def deletedeploykey(self, id_, key_id):
@@ -961,7 +961,7 @@ class Gitlab(object):
         if request.status_code == 200:
             return True
         else:
-            
+
             return False
 
     def getreadme(self, repo, mark=False):
@@ -1015,7 +1015,7 @@ class Gitlab(object):
         if request.status_code == 200:
             return json.loads(request.content.decode("utf-8"))
         else:
-            
+
             return False
 
     def moveproject(self, group_id, project_id):
@@ -1031,7 +1031,7 @@ class Gitlab(object):
         if request.status_code == 201:
             return True
         else:
-            
+
             return False
 
     def getmergerequests(self, project_id, page=1, per_page=20, sudo=""):
@@ -1051,7 +1051,7 @@ class Gitlab(object):
         if request.status_code == 200:
             return json.loads(request.content.decode("utf-8"))
         else:
-            
+
             return False
 
     def getmergerequest(self, project_id, mergerequest_id):
@@ -1069,7 +1069,7 @@ class Gitlab(object):
         if request.status_code == 200:
             return json.loads(request.content.decode("utf-8"))
         else:
-            
+
             return False
 
     def createmergerequest(self, project_id, sourcebranch, targetbranch,
@@ -1090,12 +1090,12 @@ class Gitlab(object):
         if sudo != "":
             data['sudo'] = sudo
 
-        request = requests.post(url_str, data=data, headers=self.headers, 
+        request = requests.post(url_str, data=data, headers=self.headers,
                                 verify=self.verify_ssl)
         if request.status_code == 201:
             return True
         else:
-            
+
             return False
 
     def updatemergerequest(self, project_id, mergerequest_id, sourcebranch=None,
@@ -1122,12 +1122,12 @@ class Gitlab(object):
         if sudo != "":
             data['sudo'] = sudo
 
-        request = requests.post(url_str, data=data, headers=self.headers, 
+        request = requests.post(url_str, data=data, headers=self.headers,
                                 verify=self.verify_ssl)
         if request.status_code == 201:
             return True
         else:
-            
+
             return False
 
     def addcommenttomergerequest(self, project_id, mergerequest_id, note):
@@ -1146,7 +1146,7 @@ class Gitlab(object):
         if request.status_code == 201:
             return True
         else:
-            
+
             return False
 
     def getsnippets(self, project_id):
@@ -1385,7 +1385,7 @@ class Gitlab(object):
         else:
             return False
 
-    def addgroupmember(self, group_id, user_id, access_level, sudo=""):
+    def addgroupmember(self, group_id, user_id, access_level, sudo="", custom=10):
         """
         add a user to a group
         new in 6.2
@@ -1405,8 +1405,10 @@ class Gitlab(object):
             access_level = 30
         elif access_level.lower() == "reporter":
             access_level = 20
-        else:
+        elif access_level.lower() == "group":
             access_level = 10
+        else:
+            access_level = custom
         data = {"id": group_id, "user_id": user_id, "access_level": access_level}
         if sudo != "":
             data['sudo'] = sudo


### PR DESCRIPTION
Rationale: Some developers may need to create custom access levels that is up to them to support, but the API should still allow access to them if properly defined.

The API wrappers should also reflect this and this pull request helps the Python API wrapper achieve greater parity with the actual API capabilities in this regard.
