### PR TITLE
Allow to search users

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -148,7 +148,7 @@ Edit user details::
 
 Get all the users::
 
-   print git.getusers()
+   print git.getusers(search=None)
 
 Get the current user::
 

--- a/gitlab/__init__.py
+++ b/gitlab/__init__.py
@@ -59,14 +59,17 @@ class Gitlab(object):
         else:
             raise exceptions.HttpError(json.loads(request.content)['message'])
 
-    def getusers(self, page=1, per_page=20):
+    def getusers(self, search=None, page=1, per_page=20):
         """
         Return a user list
+        :param search: Optional search query
         :param page: Which page to return (default is 1)
         :param per_page: Number of items to return per page (default is 20)
         return: returs a dictionary of the users, false if there is an error
         """
         data = {'page': page, 'per_page': per_page}
+        if search:
+            data['search'] = search
         request = requests.get(self.users_url, params=data,
                                headers=self.headers, verify=self.verify_ssl)
         if request.status_code == 200:


### PR DESCRIPTION
Gitlab api allow an optional parameter, search, to search users.

https://github.com/gitlabhq/gitlabhq/blob/master/doc/api/users.md
