### PR TITLE
Update test suite for python3 compat

### DIFF
--- a/tests/pyapi-gitlab_test.py
+++ b/tests/pyapi-gitlab_test.py
@@ -145,5 +145,5 @@ class GitlabTest(unittest.TestCase):
     def test_group(self):
         self.assertTrue(self.git.creategroup("test_group", "test"))
         assert isinstance(self.git.getgroups(), list)
-        print self.git.getgroups()
+        print(self.git.getgroups())
         #self.assertTrue(self.git.deletegroup(self.git.getgroups()[:-1]))


### PR DESCRIPTION
print is a function in python3, parenthesis required => pip in python3.4 warned me
