### PR TITLE
Pass the verify_ssl instance variable to all requests

### DIFF
--- a/gitlab/__init__.py
+++ b/gitlab/__init__.py
@@ -131,7 +131,7 @@ class Gitlab(object):
         good way of differenting them
         """
         request = requests.delete(self.users_url + "/" + str(id_),
-                                  headers=self.headers)
+                                  headers=self.headers, verify=self.verify_ssl)
         if request.status_code == 200:
             return True
         else:
@@ -206,7 +206,8 @@ class Gitlab(object):
         if sudo != "":
             data['sudo'] = sudo
         request = requests.put(self.users_url + "/" + str(id_),
-                               headers=self.headers, data=data)
+                               headers=self.headers, data=data,
+                               verify=self.verify_ssl)
         if request.status_code == 404:
             return True
         # There is a problem here and that is that the api always return 404,
@@ -288,7 +289,7 @@ class Gitlab(object):
         :return: False if it didn't delete it, True if it was deleted
         """
         request = requests.delete(self.keys_url + "/" + str(id_),
-                                  headers=self.headers)
+                                  headers=self.headers, verify=self.verify_ssl)
         if request.content == b"null":            
             return False
         else:
@@ -501,7 +502,8 @@ class Gitlab(object):
         if sudo != "":
             data['sudo'] = sudo
         request = requests.put(self.projects_url + "/" + str(id_) + "/members/"
-                               + str(user_id), headers=self.headers, data=data)
+                               + str(user_id), headers=self.headers, data=data,
+                               verify=self.verify_ssl)
         if request.status_code == 200:
             return True
         else:
@@ -517,7 +519,8 @@ class Gitlab(object):
         """
         request = requests.delete(self.projects_url + "/" + str(id_)
                                   + "/members/" + str(user_id),
-                                  headers=self.headers)
+                                  headers=self.headers,
+                                  verify=self.verify_ssl)
         if request.status_code == 200:
             return True  # It always returns true
 
@@ -583,7 +586,7 @@ class Gitlab(object):
             data['sudo'] = sudo
         request = requests.put(self.projects_url + "/" + str(id_) + "/hooks/" +
                                str(hook_id), headers=self.headers,
-                               data=data)
+                               data=data, verify=self.verify_ssl)
         if request.status_code == 200:
             return True
         else:
@@ -599,7 +602,8 @@ class Gitlab(object):
         """
         request = requests.delete(self.projects_url + "/" + str(id_)
                                   + "/hooks/"
-                                  + str(hook_id), headers=self.headers)
+                                  + str(hook_id), headers=self.headers,
+                                  verify=self.verify_ssl)
         if request.status_code == 200:
             return True
         else:
@@ -645,7 +649,8 @@ class Gitlab(object):
         """
         request = requests.put(self.projects_url + "/" + str(id_) +
                                "/repository/branches/" + str(branch) +
-                               "/protect", headers=self.headers)
+                               "/protect", headers=self.headers,
+                               verify=self.verify_ssl)
         if request.status_code == 200:
             return True
         else:
@@ -661,7 +666,8 @@ class Gitlab(object):
         """
         request = requests.put(self.projects_url + "/" + str(id_) +
                                "/repository/branches/" + str(branch) +
-                               "/unprotect", headers=self.headers)
+                               "/unprotect", headers=self.headers,
+                               verify=self.verify_ssl)
         if request.status_code == 200:
             return True
         else:
@@ -694,7 +700,8 @@ class Gitlab(object):
         :return: true if success
         """
         request = requests.delete(self.projects_url + "/" + str(id_) +
-                                  "/fork", headers=self.headers)
+                                  "/fork", headers=self.headers,
+                                  verify=self.verify_ssl)
         if request.status_code == 200:
             return True
         else:
@@ -892,7 +899,7 @@ class Gitlab(object):
         request = requests.put(self.projects_url + "/" + str(id_)
                                + "/milestones/"
                                + str(milestone_id), headers=self.headers,
-                               data=data)
+                               data=data, verify=self.verify_ssl)
         if request.status_code == 200:
             return True
         else:
@@ -957,7 +964,8 @@ class Gitlab(object):
         :return: true if success, false if not
         """
         request = requests.delete(self.projects_url + "/" + str(id_) + "/keys/"
-                                  + str(key_id), headers=self.headers)
+                                  + str(key_id), headers=self.headers,
+                                  verify=self.verify_ssl)
         if request.status_code == 200:
             return True
         else:
@@ -1208,7 +1216,7 @@ class Gitlab(object):
 
     def deletesnippet(self, project_id, snippet_id):
         request = requests.delete(self.projects_url + "/" + str(project_id) +
-                                  "/snippets/" + str(snippet_id), headers=self.headers)
+                                  "/snippets/" + str(snippet_id), headers=self.headers, verify=self.verify_ssl)
         if request.status_code == 200:
             return True
         else:
@@ -1238,7 +1246,7 @@ class Gitlab(object):
     def protectrepositorybranch(self, project_id, branch_name):
         request = requests.put(self.projects_url + "/" + str(project_id) +
                                "/repository/branches/" + str(branch_name) + "/protect",
-                               headers=self.headers)
+                               headers=self.headers, verify=self.verify_ssl)
         if request.status_code == 200:
             return json.loads(request.content.decode("utf-8"))
         else:
@@ -1247,7 +1255,7 @@ class Gitlab(object):
     def unprotectrepositorybranch(self, project_id, branch_name):
         request = requests.put(self.projects_url + "/" + str(project_id) +
                                "/repository/branches/" + str(branch_name) + "/unprotect",
-                               headers=self.headers)
+                               headers=self.headers, verify=self.verify_ssl)
         if request.status_code == 200:
             return json.loads(request.content.decode("utf-8"))
         else:
@@ -1363,7 +1371,7 @@ class Gitlab(object):
         good way of differentiating them
         """
         request = requests.delete(self.groups_url + "/" + str(group_id),
-                                  headers=self.headers)
+                                  headers=self.headers, verify=self.verify_ssl)
         if request.status_code == 200:
             return True
         else:
@@ -1429,7 +1437,7 @@ class Gitlab(object):
         """
         request = requests.delete(self.groups_url + "/" + str(group_id)
                                   + "/members/" + str(user_id),
-                                  headers=self.headers)
+                                  headers=self.headers, verify=self.verify_ssl)
         if request.status_code == 200:
             return True  # It always returns true
 
@@ -1614,7 +1622,7 @@ class Gitlab(object):
         data = {"file_path": file_path, "branch_name": branch_name,
                 "content": content, "commit_message": commit_message}
         request = requests.put(self.projects_url + "/" + str(project_id) + "/repository/files",
-                               headers=self.headers, data=data)
+                               headers=self.headers, data=data, verify=self.verify_ssl)
 
         if request.status_code == 200:
             return True
@@ -1633,7 +1641,8 @@ class Gitlab(object):
         data = {"file_path": file_path, "branch_name": branch_name,
                 "commit_message": commit_message}
         request = requests.delete(self.projects_url + "/" + str(project_id) + "/repository/files",
-                                  headers=self.headers, data=data)
+                                  headers=self.headers, data=data,
+                                  verify=self.verify_ssl)
 
         if request.status_code == 200:
             return True
@@ -1663,7 +1672,7 @@ class Gitlab(object):
         :return: true if success, false if not
         """
         request = requests.delete(self.projects_url + "/" + str(project_id) + "/services/gitlab-ci",
-                                  headers=self.headers)
+                                  headers=self.headers, verify=self.verify_ssl)
 
         if request.status_code == 200:
             return True


### PR DESCRIPTION
Previously, the passing of this variable was sporadic which makes
very little sense and causes issues when someone needs to communicate
with a server that doesn't have a secure certificate. Now all requests
should pass this variable allowing all functions to work with insecure
servers if the user requires it.
