### PR TITLE
Addgroupmember fixes

### DIFF
--- a/gitlab/__init__.py
+++ b/gitlab/__init__.py
@@ -1436,8 +1436,10 @@ class Gitlab(object):
                 access_level = 30
             elif access_level.lower() == "reporter":
                 access_level = 20
-            else:
+            elif access_level.lower() == "guest":
                 access_level = 10
+            else:
+                return False
 
         data = {"id": group_id, "user_id": user_id, "access_level": access_level}
         if sudo != "":

--- a/gitlab/__init__.py
+++ b/gitlab/__init__.py
@@ -1427,7 +1427,9 @@ class Gitlab(object):
         :param sudo: do the request with another user
         :return: True if success
         """
-        if access_level.lower() == "master":
+        if access_level.lower() == "owner":
+            access_level = 50
+        elif access_level.lower() == "master":
             access_level = 40
         elif access_level.lower() == "developer":
             access_level = 30

--- a/gitlab/__init__.py
+++ b/gitlab/__init__.py
@@ -1427,16 +1427,18 @@ class Gitlab(object):
         :param sudo: do the request with another user
         :return: True if success
         """
-        if access_level.lower() == "owner":
-            access_level = 50
-        elif access_level.lower() == "master":
-            access_level = 40
-        elif access_level.lower() == "developer":
-            access_level = 30
-        elif access_level.lower() == "reporter":
-            access_level = 20
-        else:
-            access_level = 10
+        if not isinstance(access_level, int):
+            if access_level.lower() == "owner":
+                access_level = 50
+            elif access_level.lower() == "master":
+                access_level = 40
+            elif access_level.lower() == "developer":
+                access_level = 30
+            elif access_level.lower() == "reporter":
+                access_level = 20
+            else:
+                access_level = 10
+
         data = {"id": group_id, "user_id": user_id, "access_level": access_level}
         if sudo != "":
             data['sudo'] = sudo


### PR DESCRIPTION
I was bitten by quite a few different aspects to the `addgroupmember()` method:
- First of all, the `access_level` parameter doesn't accept the same input as the GitLab API, even though it refers to the GitLab API documentation for help.
- It doesn't map all the available access levels into the number format that GitLab expects, so it isn't possible to add a user with the Owner access level.
- In case you enter an access level it doesn't recognize the Guest access level is used, which I think is bad practice. It should rather fail than trying to do something you don't expect.

This pull request rectifies the above aspects while retaining backwards compatibility.

I also by mistake sent a user name in the `user_id` field which didn't give any error back. While a check for that could also be added in the API (just make sure it's an integer), I have instead opted to make a [bug report for GitLab](https://gitlab.com/gitlab-org/gitlab-ce/issues/450) to at least make them check the user_id, so it doesn't mess with the system.
