### PR TITLE
Make markdown dependency optional

### DIFF
--- a/gitlab/__init__.py
+++ b/gitlab/__init__.py
@@ -430,11 +430,11 @@ class Gitlab(object):
         :return: Dict of information on the newly created project if successful,
          False otherwise
         """
-        data = {"name": name } #, "description": description,
-                # "issues_enabled": issues_enabled, "wall_enabled": wall_enabled,
-                # "merge_requests_enabled": merge_requests_enabled,
-                # "wiki_enabled": wiki_enabled,
-                # "snippets_enabled": snippets_enabled}
+        data = {"name": name, "description": description,
+                 "issues_enabled": issues_enabled, "wall_enabled": wall_enabled,
+                 "merge_requests_enabled": merge_requests_enabled,
+                 "wiki_enabled": wiki_enabled,
+                 "snippets_enabled": snippets_enabled}
         if namespace_id != None:
             data['namespace_id'] = namespace_id
         if sudo != "":

--- a/gitlab/__init__.py
+++ b/gitlab/__init__.py
@@ -6,7 +6,11 @@ by Itxaka Serrano Garcia <itxakaserrano@gmail.com>
 
 import requests
 import json
-import markdown
+try:
+    import markdown
+except Exception, e:
+    # unable to import markdown
+    pass
 from . import exceptions
 
 
@@ -1047,7 +1051,10 @@ class Gitlab(object):
                 return "There isn't a README.md for that project"
         else:
             if mark:
-                return markdown.markdown(request.content.decode('utf-8'))
+		try: 
+                    return markdown.markdown(request.content.decode('utf-8'))
+		except Exception, e:
+		    return request.content.decode('utf-8')		  
             else:
                 return request.content.decode('utf-8')
 

--- a/gitlab/__init__.py
+++ b/gitlab/__init__.py
@@ -1051,10 +1051,10 @@ class Gitlab(object):
                 return "There isn't a README.md for that project"
         else:
             if mark:
-		try: 
+                try: 
                     return markdown.markdown(request.content.decode('utf-8'))
-		except Exception as e:
-		    return request.content.decode('utf-8')		  
+                except Exception as e:
+                    return request.content.decode('utf-8')
             else:
                 return request.content.decode('utf-8')
 

--- a/gitlab/__init__.py
+++ b/gitlab/__init__.py
@@ -8,7 +8,7 @@ import requests
 import json
 try:
     import markdown
-except Exception, e:
+except Exception as e:
     # unable to import markdown
     pass
 from . import exceptions
@@ -1053,7 +1053,7 @@ class Gitlab(object):
             if mark:
 		try: 
                     return markdown.markdown(request.content.decode('utf-8'))
-		except Exception, e:
+		except Exception as e:
 		    return request.content.decode('utf-8')		  
             else:
                 return request.content.decode('utf-8')


### PR DESCRIPTION
Markdown is no longer supported on python 2.6, which is the default on CentOS 6.  Since markdown is not integral to any function except getting the readme when the mark flag is passed, this patch simply catches the exception that is thrown when markdown is not supported and returns the plain text.
