### PR TITLE
Markdown needs to be an optional dependency in the setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     install_requires = ['requests'],
     extras_require = {
         'markdown':  ["markdown"]
-    }
+    },
     # metadata for upload to PyPI
     author = "Itxaka Serrano Garcia",
     author_email = "itxakaserrano@gmail.com",

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     packages = find_packages(),
     install_requires = ['requests'],
     extras_require = {
-        'markdown':  ["markdown"],
+        'markdown':  ["markdown"]
     }
     # metadata for upload to PyPI
     author = "Itxaka Serrano Garcia",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,10 @@ setup(
     name = "pyapi-gitlab",
     version = "6.2.3",
     packages = find_packages(),
-    install_requires = ['requests', 'markdown'],
+    install_requires = ['requests'],
+    extras_require = {
+        'markdown':  ["markdown"],
+    }
     # metadata for upload to PyPI
     author = "Itxaka Serrano Garcia",
     author_email = "itxakaserrano@gmail.com",


### PR DESCRIPTION
My last pull request made it so that markdown is optional - but the setup.py is still requiring it.  This commit solves that.
