### PR TITLE
only catch actual ImportError, which is self-explaining, too

### DIFF
--- a/gitlab/__init__.py
+++ b/gitlab/__init__.py
@@ -8,8 +8,7 @@ import requests
 import json
 try:
     import markdown
-except Exception as e:
-    # unable to import markdown
+except ImportError:
     pass
 from . import exceptions
 


### PR DESCRIPTION
Not being able to import a module raises an ImportError, so that is the only one to be ignored,not any exception such as e.g. a typo in the imporrt statement or any errors in the markdown module.
As the comment does not convey any more informatin that "except ImportError" already does, I removed it. If you do prefer to have a comment there, I'd suggest something like "markdown is optional".
