### PR TITLE
do not use generic Exception

### DIFF
--- a/gitlab/__init__.py
+++ b/gitlab/__init__.py
@@ -56,7 +56,7 @@ class Gitlab(object):
         elif email != None:
             data = {"email": email, "password": password}
         else:
-            raise Exception('Neither username nor email provided to login')
+            raise ValueError('Neither username nor email provided to login')
 
         request = requests.post(self.host + "/api/v3/session", data=data, 
                                 verify=self.verify_ssl,


### PR DESCRIPTION
Raising a generic Exception is generally  bad, because it can only be caught by catching all exception types. Even if not passing proper arguments in this case rather is a programming error by the caller who should not catch it, raising a specific exception is still nicer. :)
Being rather a programming error, I opted for using ValueError instead of adding another custom type to exceptions.
