### PR TITLE
avoid IndexError when empty host argument is given

### DIFF
--- a/gitlab/__init__.py
+++ b/gitlab/__init__.py
@@ -27,6 +27,8 @@ class Gitlab(object):
         if token != "":
             self.token = token
             self.headers = {"PRIVATE-TOKEN": self.token}
+        if not host:
+            raise ValueError("host argument may not be empty")
         if host[-1] == '/':
             self.host = host[:-1]
         else:


### PR DESCRIPTION
When the host argument passed to **inint** is an empty string, tryping to access host[-1] raises an IndexError.
As an empty hostname is not valid anyway, a ValueError with an according error meassage is raised instead.
