### PR TITLE
remove decode

### DIFF
--- a/gitlab/__init__.py
+++ b/gitlab/__init__.py
@@ -1404,7 +1404,7 @@ class Gitlab(object):
                                params=data, verify=self.verify_ssl,
                                headers=self.headers)
         if request.status_code == 200:
-            return request.content.decode("utf-8")
+            return request.content
         else:
             return False
 
@@ -1418,7 +1418,7 @@ class Gitlab(object):
         request = requests.get("{0}/{1}/repository/raw_blobs/{2}".format(self.projects_url, project_id, sha1),
                                verify=self.verify_ssl, headers=self.headers)
         if request.status_code == 200:
-            return request.content.decode("utf-8")
+            return request.content
         else:
             return False
 


### PR DESCRIPTION
it's unnecessary to decode raw blob or file here, otherwise when you get binary file like *.ttf and *.eot from `getrawfile` you'll get an error.
