### PR TITLE
Add a convenience method to Get All results from paginated calls

### DIFF
--- a/gitlab/__init__.py
+++ b/gitlab/__init__.py
@@ -1850,3 +1850,16 @@ class Gitlab(object):
             return json.loads(request.content.decode("utf-8"))
         else:
             return False
+
+    @staticmethod
+    def getall(fn, *args, **kwargs):
+        """auto iterate over results
+        """
+        page = kwargs.pop('page', 1)
+        while True:
+            results = fn(*args, page=page, **kwargs)
+            if not results:
+                break
+            for x in results:
+                yield x
+            page += 1

--- a/gitlab/__init__.py
+++ b/gitlab/__init__.py
@@ -1853,7 +1853,17 @@ class Gitlab(object):
 
     @staticmethod
     def getall(fn, *args, **kwargs):
-        """auto iterate over results
+        """Auto-iterate over the paginated results of various methods of the API.
+        Pass the GitLabAPI method as the first argument, followed by the
+        other parameters as normal. Include `page` to determine first page to poll.
+        Remaining kwargs are passed on to the called method, including `per_page`.
+
+        :param fn: Actual method to call
+        :param *args: Positional arguments to actual method
+        :param page: Optional, page number to start at, defaults to 1
+        :param **kwargs: Keyword arguments to actual method
+        :return: Yields each item in the result until exhausted, and then
+        implicit StopIteration; or no elements if error
         """
         page = kwargs.pop('page', 1)
         while True:


### PR DESCRIPTION
As has been discussed in issue #37 and others, there should be a way for users of this API to easily **get all** the results for an API call without having to do the pagination themselves. Especially since most users would want that most of the time, instead of specific pages or ranges.

I agree that the default behaviour should remain paginated, so that it's clear that we'll be dealing with it. So better than modifying the existing functions' understood functionality, a convenience method - as a wrapper - to get all the results of a paginated call would be ideal. It has the added benefit of not requiring each user of the API to write their own.

This may have been covered in [this gist](https://gist.github.com/sag47/6937133) but I wasn't able to view that since it no longer exists.

Note: Since the starting `page` can be specified in `kwargs`, it makes sense to allow a `last` page param as well. Would be trivial to add that in.
