### PR TITLE
add editgroupmember() method

### DIFF
--- a/gitlab/__init__.py
+++ b/gitlab/__init__.py
@@ -1592,6 +1592,37 @@ class Gitlab(object):
         else:
             return False
 
+    def editgroupmember(self, group_id, user_id, access_level):
+        """Edit user access level in a group
+
+        :param group_id: group id
+        :param user_id: user id
+        :param access_level: access level, see gitlab help to know more
+        :return: True if success
+        """
+        if not isinstance(access_level, int):
+            if access_level.lower() == "owner":
+                access_level = 50
+            elif access_level.lower() == "master":
+                access_level = 40
+            elif access_level.lower() == "developer":
+                access_level = 30
+            elif access_level.lower() == "reporter":
+                access_level = 20
+            elif access_level.lower() == "guest":
+                access_level = 10
+            else:
+                return False
+
+        data = {"id": group_id, "user_id": user_id, "access_level": access_level}
+
+        request = requests.put("{0}/{1}/members/{2}".format(self.groups_url, group_id, user_id),
+                                headers=self.headers, data=data, verify=self.verify_ssl)
+        if request.status_code == 200:
+            return True
+        else:
+            return False
+
     def deletegroupmember(self, group_id, user_id):
         """Delete a group member
 

--- a/gitlab/__init__.py
+++ b/gitlab/__init__.py
@@ -995,15 +995,21 @@ class Gitlab(object):
 
             return False
 
-    def creategroup(self, name, path):
+    def creategroup(self, name, path, **kwargs):
         """Creates a new group
 
         :param name: The name of the group
         :param path: The path for the group
+        :param kwargs: Any param the the Gitlab API supports
         :return: dict of the new group
         """
-        request = requests.post(self.groups_url,
-                                data={'name': name, 'path': path},
+
+        data = {'name': name, 'path': path}
+
+        if kwargs:
+            data.update(kwargs)
+
+        request = requests.post(self.groups_url, data=data,
                                 headers=self.headers, verify=self.verify_ssl)
         if request.status_code == 201:
             return json.loads(request.content.decode("utf-8"))


### PR DESCRIPTION
Hi,

This method use API to call [Edit group team member](https://github.com/gitlabhq/gitlabhq/blob/master/doc/api/groups.md#edit-group-team-member). I try to add also test case but I'm not sure how to write it. This API feature appear in 7.8 version of GitLab.

GitLab API also now accept _description_ parameter [during group creation](https://gitlab.com/gitlab-org/gitlab-ce/blob/v7.10.2/doc/api/groups.md#new-group). To manage it, I patch _creategroup_ method to accept _kargws_ (as _createuser_ method).
