### PR TITLE
Commit comment

### DIFF
--- a/gitlab/__init__.py
+++ b/gitlab/__init__.py
@@ -14,7 +14,6 @@ except ImportError:
     from urllib.parse import quote_plus
     basestring = str
 
-
 class Gitlab(object):
     """Gitlab class"""
 
@@ -1373,6 +1372,33 @@ class Gitlab(object):
             return request.json()
         else:
             return False
+
+    def addcommenttocommit(self, project_id, author, sha, path, line, note):
+        """Adds an inline comment to a specific commit
+        :param project_id project id
+        :param author The author info as returned by createmergerequest
+        :param sha The name of a repository branch or tag or if not given the default branch
+        :param path The file path
+        :param line The line number
+        :param note Text of comment
+        """
+
+        data = {
+            "author": author,
+            "note": note,
+            "path": path,
+            "line": line,
+            "line_type": "new"
+        }
+
+        request = requests.post("{0}/{1}/repository/commits/{2}/comments".format(self.projects_url, project_id, sha),
+                                headers=self.headers, data=data, verify=self.verify_ssl)
+        if request.status_code == 201:
+            return True
+        else:
+
+            return False
+
 
     def getrepositorycommits(self, project_id, ref_name=None, page=1, per_page=20):
         """Get a list of repository commits in a project.

--- a/gitlab_tests/pyapi-gitlab_test.py
+++ b/gitlab_tests/pyapi-gitlab_test.py
@@ -315,6 +315,14 @@ class GitlabTest(unittest.TestCase):
         self.assertTrue(self.git.acceptmergerequest(self.project_id, merge["id"], "closed!"))
         self.assertEqual(self.git.getmergerequest(self.project_id, merge["id"])["state"], "merged")
 
+    def test_commit_comment(self):
+        commit = self.git.getrepositorycommits(self.project_id)[5]
+        branch = self.git.createbranch(self.project_id, "mergebranch", commit["id"])
+        merge = self.git.createmergerequest(self.project_id, "develop", "mergebranch", "testmerge")
+
+        self.assertTrue(self.git.addcommenttocommit(self.project_id, merge['author'], merge['source_branch'], 'README.md', 1, 'Hello'))
+
+
     def test_notes(self):
 
         # issue wallnotes


### PR DESCRIPTION
This merge adds support for inlining commenting of diffs:

https://gitlab.com/gitlab-org/gitlab-ce/merge_requests/137/diffs
