### PR TITLE
Handle HTTP Basic Auth

### DIFF
--- a/gitlab/__init__.py
+++ b/gitlab/__init__.py
@@ -18,7 +18,7 @@ except ImportError:
 class Gitlab(object):
     """Gitlab class"""
 
-    def __init__(self, host, token="", oauth_token="", verify_ssl=True):
+    def __init__(self, host, token="", oauth_token="", verify_ssl=True, auth=None):
         """on init we setup the token used for all the api calls and all the urls
 
         :param host: host of gitlab
@@ -39,6 +39,7 @@ class Gitlab(object):
         else:
             self.host = 'https://' + self.host
 
+        self.auth = auth
         self.api_url = self.host + "/api/v3"
         self.projects_url = self.api_url + "/projects"
         self.users_url = self.api_url + "/users"
@@ -63,7 +64,7 @@ class Gitlab(object):
             raise ValueError('Neither username nor email provided to login')
 
         request = requests.post("{0}/api/v3/session".format(self.host), data=data,
-                                verify=self.verify_ssl,
+                                verify=self.verify_ssl, auth=self.auth,
                                 headers={"connection": "close"})
         if request.status_code == 201:
             self.token = request.json()['private_token']
@@ -100,7 +101,7 @@ class Gitlab(object):
         if search:
             data['search'] = search
         request = requests.get(self.users_url, params=data,
-                               headers=self.headers, verify=self.verify_ssl)
+                               headers=self.headers, verify=self.verify_ssl, auth=self.auth)
         if request.status_code == 200:
             return request.json()
         else:
@@ -113,7 +114,7 @@ class Gitlab(object):
         :return: False if not found, a dictionary if found
         """
         request = requests.get("{0}/{1}".format(self.users_url, user_id),
-                               headers=self.headers, verify=self.verify_ssl)
+                               headers=self.headers, verify=self.verify_ssl, auth=self.auth)
         if request.status_code == 200:
             return request.json()
         else:
@@ -135,7 +136,7 @@ class Gitlab(object):
             data.update(kwargs)
 
         request = requests.post(self.users_url, headers=self.headers, data=data,
-                                verify=self.verify_ssl)
+                                verify=self.verify_ssl, auth=self.auth)
         if request.status_code == 201:
             return request.json()
         elif request.status_code == 404:
@@ -148,7 +149,7 @@ class Gitlab(object):
         :return: True if it deleted, False if it couldn't. False could happen for several reasons, but there isn't a good way of differenting them
         """
         request = requests.delete("{0}/{1}".format(self.users_url, user_id),
-                                  headers=self.headers, verify=self.verify_ssl)
+                                  headers=self.headers, verify=self.verify_ssl, auth=self.auth)
         if request.status_code == 200:
             return True
         else:
@@ -161,7 +162,7 @@ class Gitlab(object):
         :return: a list with the current user properties
         """
         request = requests.get("{0}/api/v3/user".format(self.host),
-                               headers=self.headers, verify=self.verify_ssl)
+                               headers=self.headers, verify=self.verify_ssl, auth=self.auth)
         return request.json()
 
     def edituser(self, user_id, **kwargs):
@@ -178,7 +179,7 @@ class Gitlab(object):
 
         request = requests.put("{0}/{1}".format(self.users_url, user_id),
                                headers=self.headers, data=data,
-                               verify=self.verify_ssl)
+                               verify=self.verify_ssl, auth=self.auth)
         if request.status_code == 200:
             return request.json()
         else:
@@ -190,7 +191,7 @@ class Gitlab(object):
         :return: a dictionary with the lists
         """
         request = requests.get(self.keys_url, headers=self.headers,
-                               verify=self.verify_ssl)
+                               verify=self.verify_ssl, auth=self.auth)
         if request.status_code == 200:
             return request.json()
         else:
@@ -204,7 +205,7 @@ class Gitlab(object):
         :return: the key itself
         """
         request = requests.get("{0}/{1}".format(self.keys_url, key_id),
-                               headers=self.headers, verify=self.verify_ssl)
+                               headers=self.headers, verify=self.verify_ssl, auth=self.auth)
         if request.status_code == 200:
             return request.json()
         else:
@@ -220,7 +221,7 @@ class Gitlab(object):
         """
         data = {"title": title, "key": key}
         request = requests.post(self.keys_url, headers=self.headers, data=data,
-                                verify=self.verify_ssl)
+                                verify=self.verify_ssl, auth=self.auth)
         if request.status_code == 201:
             return True
         else:
@@ -237,7 +238,7 @@ class Gitlab(object):
         data = {"title": title, "key": key}
 
         request = requests.post("{0}/{1}/keys".format(self.users_url, user_id),
-                                headers=self.headers, data=data, verify=self.verify_ssl)
+                                headers=self.headers, data=data, verify=self.verify_ssl, auth=self.auth)
         if request.status_code == 201:
             return True
         else:
@@ -250,7 +251,7 @@ class Gitlab(object):
         :return: False if it didn't delete it, True if it was deleted
         """
         request = requests.delete("{0}/{1}".format(self.keys_url, key_id),
-                                  headers=self.headers, verify=self.verify_ssl)
+                                  headers=self.headers, verify=self.verify_ssl, auth=self.auth)
         if request.content == b"null":
             return False
         else:
@@ -264,7 +265,7 @@ class Gitlab(object):
         data = {'page': page, 'per_page': per_page}
 
         request = requests.get(self.projects_url, params=data,
-                               headers=self.headers, verify=self.verify_ssl)
+                               headers=self.headers, verify=self.verify_ssl, auth=self.auth)
         if request.status_code == 200:
             return request.json()
         else:
@@ -278,7 +279,7 @@ class Gitlab(object):
         data = {'page': page, 'per_page': per_page}
 
         request = requests.get("{0}/all".format(self.projects_url), params=data,
-                               headers=self.headers, verify=self.verify_ssl)
+                               headers=self.headers, verify=self.verify_ssl, auth=self.auth)
         if request.status_code == 200:
             return request.json()
         else:
@@ -292,7 +293,7 @@ class Gitlab(object):
         data = {'page': page, 'per_page': per_page}
 
         request = requests.get("{0}/owned".format(self.projects_url), params=data,
-                               headers=self.headers, verify=self.verify_ssl)
+                               headers=self.headers, verify=self.verify_ssl, auth=self.auth)
         if request.status_code == 200:
             return request.json()
         else:
@@ -307,7 +308,7 @@ class Gitlab(object):
         if isinstance(project_id, basestring):
             project_id = quote_plus(project_id)
         request = requests.get("{0}/{1}".format(self.projects_url, project_id),
-                               headers=self.headers, verify=self.verify_ssl)
+                               headers=self.headers, verify=self.verify_ssl, auth=self.auth)
         if request.status_code == 200:
             return request.json()
         else:
@@ -321,7 +322,7 @@ class Gitlab(object):
         """
         data = {'page': page, 'per_page': per_page}
         request = requests.get("{0}/{1}/events".format(self.projects_url, project_id), params=data, headers=self.headers,
-                               verify=self.verify_ssl)
+                               verify=self.verify_ssl, auth=self.auth)
         if request.status_code == 200:
             return request.json()
         else:
@@ -350,7 +351,7 @@ class Gitlab(object):
             data.update(kwargs)
 
         request = requests.post(self.projects_url, headers=self.headers,
-                                data=data, verify=self.verify_ssl)
+                                data=data, verify=self.verify_ssl, auth=self.auth)
         if request.status_code == 201:
             return request.json()
         elif request.status_code == 403:
@@ -381,7 +382,7 @@ class Gitlab(object):
             data.update(kwargs)
 
         request = requests.put("{0}/{1}".format(self.projects_url, project_id),
-                                            headers=self.headers, data=data, verify=self.verify_ssl)
+                                            headers=self.headers, data=data, verify=self.verify_ssl, auth=self.auth)
 
         if request.status_code == 200:
             return True
@@ -400,7 +401,7 @@ class Gitlab(object):
         :return: always true
         """
         request = requests.delete("{0}/{1}".format(self.projects_url, project_id),
-                                  headers=self.headers, verify=self.verify_ssl)
+                                  headers=self.headers, verify=self.verify_ssl, auth=self.auth)
         if request.status_code == 200:
             return True
 
@@ -427,7 +428,7 @@ class Gitlab(object):
             data.update(kwargs)
 
         request = requests.post("{0}/user/{1}".format(self.projects_url, user_id),
-                                headers=self.headers, data=data, verify=self.verify_ssl)
+                                headers=self.headers, data=data, verify=self.verify_ssl, auth=self.auth)
         if request.status_code == 201:
             return True
         else:
@@ -448,7 +449,7 @@ class Gitlab(object):
             data['query'] = query
         request = requests.get("{0}/{1}/members".format(self.projects_url, project_id),
                                params=data, headers=self.headers,
-                               verify=self.verify_ssl)
+                               verify=self.verify_ssl, auth=self.auth)
         if request.status_code == 200:
             return request.json()
         else:
@@ -474,7 +475,7 @@ class Gitlab(object):
         data = {"id": project_id, "user_id": user_id, "access_level": access_level}
 
         request = requests.post("{0}/{1}/members".format(self.projects_url, project_id),
-                                headers=self.headers, data=data, verify=self.verify_ssl)
+                                headers=self.headers, data=data, verify=self.verify_ssl, auth=self.auth)
         if request.status_code == 201:
             return True
         else:
@@ -500,7 +501,7 @@ class Gitlab(object):
                 "access_level": access_level}
 
         request = requests.put("{0}/{1}/members/{2}".format(self.projects_url, project_id, user_id),
-                               headers=self.headers, data=data, verify=self.verify_ssl)
+                               headers=self.headers, data=data, verify=self.verify_ssl, auth=self.auth)
         if request.status_code == 200:
             return True
         else:
@@ -514,7 +515,7 @@ class Gitlab(object):
         :return: always true
         """
         request = requests.delete("{0}/{1}/members/{2}".format(self.projects_url, project_id, user_id),
-                                  headers=self.headers, verify=self.verify_ssl)
+                                  headers=self.headers, verify=self.verify_ssl, auth=self.auth)
         if request.status_code == 200:
             return True  # It always returns true
 
@@ -526,7 +527,7 @@ class Gitlab(object):
         """
         data = {'page': page, 'per_page': per_page}
         request = requests.get("{0}/{1}/hooks".format(self.projects_url, project_id), params=data,
-                               headers=self.headers, verify=self.verify_ssl)
+                               headers=self.headers, verify=self.verify_ssl, auth=self.auth)
         if request.status_code == 200:
             return request.json()
         else:
@@ -540,7 +541,7 @@ class Gitlab(object):
         :return: the hook
         """
         request = requests.get("{0}/{1}/hooks/{2}".format(self.projects_url, project_id, hook_id),
-                               headers=self.headers, verify=self.verify_ssl)
+                               headers=self.headers, verify=self.verify_ssl, auth=self.auth)
         if request.status_code == 200:
             return request.json()
         else:
@@ -559,7 +560,7 @@ class Gitlab(object):
         data['merge_requests_events'] = int(bool(merge_requests))
         data['tag_push_events'] = int(bool(tag_push))
         request = requests.post("{0}/{1}/hooks".format(self.projects_url, project_id),
-                                headers=self.headers, data=data, verify=self.verify_ssl)
+                                headers=self.headers, data=data, verify=self.verify_ssl, auth=self.auth)
         if request.status_code == 201:
             return request.json()
         else:
@@ -580,7 +581,7 @@ class Gitlab(object):
         data['merge_requests_events'] = int(bool(merge_requests))
         data['tag_push_events'] = int(bool(tag_push))
         request = requests.put("{0}/{1}/hooks/{2}".format(self.projects_url, project_id, hook_id),
-                               headers=self.headers, data=data, verify=self.verify_ssl)
+                               headers=self.headers, data=data, verify=self.verify_ssl, auth=self.auth)
         if request.status_code == 200:
             return True
         else:
@@ -594,7 +595,7 @@ class Gitlab(object):
         :return: True if success
         """
         request = requests.delete("{0}/{1}/hooks/{2}".format(self.projects_url, project_id, hook_id),
-                                  headers=self.headers, verify=self.verify_ssl)
+                                  headers=self.headers, verify=self.verify_ssl, auth=self.auth)
         if request.status_code == 200:
             return True
         else:
@@ -606,7 +607,7 @@ class Gitlab(object):
         :return: list of hooks
         """
         data = {'page': page, 'per_page': per_page}
-        request = requests.get(self.hook_url, params=data, headers=self.headers, verify=self.verify_ssl)
+        request = requests.get(self.hook_url, params=data, headers=self.headers, verify=self.verify_ssl, auth=self.auth)
         if request.status_code == 200:
             return request.json()
         else:
@@ -620,7 +621,7 @@ class Gitlab(object):
         """
         data = {"url": url}
         request = requests.post(self.hook_url, headers=self.headers,
-                                data=data, verify=self.verify_ssl)
+                                data=data, verify=self.verify_ssl, auth=self.auth)
         if request.status_code == 201:
             return True
         else:
@@ -634,7 +635,7 @@ class Gitlab(object):
         """
         data = {"id": hook_id}
         request = requests.get(self.hook_url, data=data,
-                               headers=self.headers, verify=self.verify_ssl)
+                               headers=self.headers, verify=self.verify_ssl, auth=self.auth)
         if request.status_code == 200:
             return request.json()
         else:
@@ -648,7 +649,7 @@ class Gitlab(object):
         """
         data = {"id": hook_id}
         request = requests.delete("{0}/{1}".format(self.hook_url, hook_id), data=data,
-                                  headers=self.headers, verify=self.verify_ssl)
+                                  headers=self.headers, verify=self.verify_ssl, auth=self.auth)
         if request.status_code == 200:
             return True
         else:
@@ -661,7 +662,7 @@ class Gitlab(object):
         :return: the branches
         """
         request = requests.get("{0}/{1}/repository/branches".format(self.projects_url, project_id),
-                               headers=self.headers, verify=self.verify_ssl)
+                               headers=self.headers, verify=self.verify_ssl, auth=self.auth)
         if request.status_code == 200:
             return request.json()
         else:
@@ -675,7 +676,7 @@ class Gitlab(object):
         :return: the branch
         """
         request = requests.get("{0}/{1}/repository/branches/{2}".format(self.projects_url, project_id, branch),
-                               headers=self.headers, verify=self.verify_ssl)
+                               headers=self.headers, verify=self.verify_ssl, auth=self.auth)
         if request.status_code == 200:
             return request.json()
         else:
@@ -692,7 +693,7 @@ class Gitlab(object):
         data = {"id": project_id, "branch_name": branch, "ref": ref}
 
         request = requests.post("{0}/{1}/repository/branches".format(self.projects_url, project_id),
-                                headers=self.headers, data=data, verify=self.verify_ssl)
+                                headers=self.headers, data=data, verify=self.verify_ssl, auth=self.auth)
         if request.status_code == 201:
             return request.json()
         else:
@@ -707,7 +708,7 @@ class Gitlab(object):
         """
 
         request = requests.delete("{0}/{1}/repository/branches/{2}".format(self.projects_url, project_id, branch),
-                                  headers=self.headers, verify=self.verify_ssl)
+                                  headers=self.headers, verify=self.verify_ssl, auth=self.auth)
 
         if request.status_code == 200:
             return True
@@ -722,7 +723,7 @@ class Gitlab(object):
         :return: True if success
         """
         request = requests.put("{0}/{1}/repository/branches/{2}/protect".format(self.projects_url, project_id, branch),
-                               headers=self.headers, verify=self.verify_ssl)
+                               headers=self.headers, verify=self.verify_ssl, auth=self.auth)
         if request.status_code == 200:
             return True
         else:
@@ -736,7 +737,7 @@ class Gitlab(object):
         :return: true if success
         """
         request = requests.put("{0}/{1}/repository/branches/{2}/unprotect".format(self.projects_url, project_id, branch),
-                               headers=self.headers, verify=self.verify_ssl)
+                               headers=self.headers, verify=self.verify_ssl, auth=self.auth)
         if request.status_code == 200:
             return True
         else:
@@ -751,7 +752,7 @@ class Gitlab(object):
         """
         data = {"id": project_id, "forked_from_id": from_project_id}
         request = requests.post("{0}/{1}/fork/{2}".format(self.projects_url, project_id, from_project_id),
-                                headers=self.headers, data=data, verify=self.verify_ssl)
+                                headers=self.headers, data=data, verify=self.verify_ssl, auth=self.auth)
         if request.status_code == 201:
             return True
         else:
@@ -764,7 +765,7 @@ class Gitlab(object):
         :return: true if success
         """
         request = requests.delete("{0}/{1}/fork".format(self.projects_url, project_id),
-                                  headers=self.headers, verify=self.verify_ssl)
+                                  headers=self.headers, verify=self.verify_ssl, auth=self.auth)
         if request.status_code == 200:
             return True
         else:
@@ -792,7 +793,7 @@ class Gitlab(object):
         data = {'page': page, 'per_page': per_page}
 
         request = requests.get("{0}/api/v3/issues".format(self.host),
-                               params=data, headers=self.headers, verify=self.verify_ssl)
+                               params=data, headers=self.headers, verify=self.verify_ssl, auth=self.auth)
         if request.status_code == 200:
             return request.json()
         else:
@@ -809,7 +810,7 @@ class Gitlab(object):
         data = kwargs
 
         request = requests.get("{0}/{1}/issues".format(self.projects_url, project_id),
-                               params=data, headers=self.headers, verify=self.verify_ssl)
+                               params=data, headers=self.headers, verify=self.verify_ssl, auth=self.auth)
         if request.status_code == 200:
             return request.json()
         else:
@@ -823,7 +824,7 @@ class Gitlab(object):
         :return: the issue
         """
         request = requests.get("{0}/{1}/issues/{2}".format(self.projects_url, project_id, issue_id),
-                               headers=self.headers, verify=self.verify_ssl)
+                               headers=self.headers, verify=self.verify_ssl, auth=self.auth)
         if request.status_code == 200:
             return request.json()
         else:
@@ -840,7 +841,7 @@ class Gitlab(object):
         if kwargs:
             data.update(kwargs)
         request = requests.post("{0}/{1}/issues".format(self.projects_url, project_id),
-                                headers=self.headers, data=data, verify=self.verify_ssl)
+                                headers=self.headers, data=data, verify=self.verify_ssl, auth=self.auth)
         if request.status_code == 201:
             return request.json()
         else:
@@ -857,7 +858,7 @@ class Gitlab(object):
         if kwargs:
             data.update(kwargs)
         request = requests.put("{0}/{1}/issues/{2}".format(self.projects_url, project_id, issue_id),
-                               headers=self.headers, data=data, verify=self.verify_ssl)
+                               headers=self.headers, data=data, verify=self.verify_ssl, auth=self.auth)
         if request.status_code == 200:
             return request.json()
         else:
@@ -871,7 +872,7 @@ class Gitlab(object):
         """
         data = {'page': page, 'per_page': per_page}
         request = requests.get("{0}/{1}/milestones".format(self.projects_url, project_id), params=data,
-                               headers=self.headers, verify=self.verify_ssl)
+                               headers=self.headers, verify=self.verify_ssl, auth=self.auth)
         if request.status_code == 200:
             return request.json()
         else:
@@ -885,7 +886,7 @@ class Gitlab(object):
         :return: dict with the new milestone
         """
         request = requests.get("{0}/{1}/milestones/{2}".format(self.projects_url, project_id, milestone_id),
-                               headers=self.headers, verify=self.verify_ssl)
+                               headers=self.headers, verify=self.verify_ssl, auth=self.auth)
         if request.status_code == 200:
             return request.json()
         else:
@@ -907,7 +908,7 @@ class Gitlab(object):
             data.update(kwargs)
 
         request = requests.post("{0}/{1}/milestones".format(self.projects_url, project_id),
-                                headers=self.headers, data=data, verify=self.verify_ssl)
+                                headers=self.headers, data=data, verify=self.verify_ssl, auth=self.auth)
         if request.status_code == 201:
             return request.json()
         else:
@@ -929,7 +930,7 @@ class Gitlab(object):
         if kwargs:
             data.update(kwargs)
         request = requests.put("{0}/{1}/milestones/{2}".format(self.projects_url, project_id, milestone_id),
-                               headers=self.headers, data=data, verify=self.verify_ssl)
+                               headers=self.headers, data=data, verify=self.verify_ssl, auth=self.auth)
         if request.status_code == 200:
             return request.json()
         else:
@@ -944,7 +945,7 @@ class Gitlab(object):
         """
         data = {'page': page, 'per_page': per_page}
         request = requests.get("{0}/{1}/milestones/{2}/issues".format(self.projects_url, project_id, milestone_id),
-                               params=data, headers=self.headers, verify=self.verify_ssl)
+                               params=data, headers=self.headers, verify=self.verify_ssl, auth=self.auth)
         if request.status_code == 200:
             return request.json()
         else:
@@ -957,7 +958,7 @@ class Gitlab(object):
         :return: the keys in a dictionary if success, false if not
         """
         request = requests.get("{0}/{1}/keys".format(self.projects_url, project_id),
-                               headers=self.headers, verify=self.verify_ssl)
+                               headers=self.headers, verify=self.verify_ssl, auth=self.auth)
         if request.status_code == 200:
             return request.json()
         else:
@@ -971,7 +972,7 @@ class Gitlab(object):
         :return: the key in a dict if success, false if not
         """
         request = requests.get("{0}/{1}/keys/{2}".format(self.projects_url, project_id, key_id),
-                               headers=self.headers, verify=self.verify_ssl)
+                               headers=self.headers, verify=self.verify_ssl, auth=self.auth)
         if request.status_code == 200:
             return request.json()
         else:
@@ -988,7 +989,7 @@ class Gitlab(object):
         data = {"id": project_id, "title": title, "key": key}
 
         request = requests.post("{0}/{1}/keys".format(self.projects_url, project_id),
-                                headers=self.headers, data=data, verify=self.verify_ssl)
+                                headers=self.headers, data=data, verify=self.verify_ssl, auth=self.auth)
         if request.status_code == 201:
             return request.json()
         else:
@@ -1002,7 +1003,7 @@ class Gitlab(object):
         :return: true if success, false if not
         """
         request = requests.delete("{0}/{1}/keys/{2}".format(self.projects_url, project_id, key_id),
-                                  headers=self.headers, verify=self.verify_ssl)
+                                  headers=self.headers, verify=self.verify_ssl, auth=self.auth)
         if request.status_code == 200:
             return True
         else:
@@ -1023,7 +1024,7 @@ class Gitlab(object):
             data.update(kwargs)
 
         request = requests.post(self.groups_url, data=data,
-                                headers=self.headers, verify=self.verify_ssl)
+                                headers=self.headers, verify=self.verify_ssl, auth=self.auth)
         if request.status_code == 201:
             return request.json()
         else:
@@ -1041,7 +1042,7 @@ class Gitlab(object):
         request = requests.get("{0}/{1}".format(self.groups_url,
                                               group_id if group_id else ""),
                                params=data, headers=self.headers,
-                               verify=self.verify_ssl)
+                               verify=self.verify_ssl, auth=self.auth)
         if request.status_code == 200:
             return request.json()
         else:
@@ -1057,7 +1058,7 @@ class Gitlab(object):
         request = requests.post("{0}/{1}/projects/{2}".format(self.groups_url,
                                                            group_id,
                                                            project_id),
-                                headers=self.headers, verify=self.verify_ssl)
+                                headers=self.headers, verify=self.verify_ssl, auth=self.auth)
         if request.status_code == 201:
             return request.json()
         else:
@@ -1073,7 +1074,7 @@ class Gitlab(object):
         data = {'page': page, 'per_page': per_page, 'state': state}
 
         request = requests.get('{0}/{1}/merge_requests'.format(self.projects_url, project_id),
-                               params=data, headers=self.headers, verify=self.verify_ssl)
+                               params=data, headers=self.headers, verify=self.verify_ssl, auth=self.auth)
 
         if request.status_code == 200:
             return request.json()
@@ -1088,7 +1089,7 @@ class Gitlab(object):
         :return: dict of the merge request
         """
         request = requests.get('{0}/{1}/merge_request/{2}'.format(self.projects_url, project_id, mergerequest_id),
-                               headers=self.headers, verify=self.verify_ssl)
+                               headers=self.headers, verify=self.verify_ssl, auth=self.auth)
 
         if request.status_code == 200:
             return request.json()
@@ -1104,7 +1105,7 @@ class Gitlab(object):
         """
         data = {'page': page, 'per_page': per_page}
         request = requests.get('{0}/{1}/merge_request/{2}/comments'.format(self.projects_url, project_id, mergerequest_id),
-                               params=data, headers=self.headers, verify=self.verify_ssl)
+                               params=data, headers=self.headers, verify=self.verify_ssl, auth=self.auth)
 
         if request.status_code == 200:
             return request.json()
@@ -1119,7 +1120,7 @@ class Gitlab(object):
         :return: information about the merge request including files and changes
         """
         request = requests.get('{0}/{1}/merge_request/{2}/changes'.format(self.projects_url, project_id, mergerequest_id),
-                               headers=self.headers, verify=self.verify_ssl)
+                               headers=self.headers, verify=self.verify_ssl, auth=self.auth)
 
         if request.status_code == 200:
             return request.json()
@@ -1144,7 +1145,7 @@ class Gitlab(object):
                 'target_project_id': target_project_id}
 
         request = requests.post('{0}/{1}/merge_requests'.format(self.projects_url, project_id),
-                                data=data, headers=self.headers, verify=self.verify_ssl)
+                                data=data, headers=self.headers, verify=self.verify_ssl, auth=self.auth)
         if request.status_code == 201:
             return request.json()
         else:
@@ -1168,7 +1169,7 @@ class Gitlab(object):
             data.update(kwargs)
 
         request = requests.put('{0}/{1}/merge_request/{2}'.format(self.projects_url, project_id, mergerequest_id),
-                               data=data, headers=self.headers, verify=self.verify_ssl)
+                               data=data, headers=self.headers, verify=self.verify_ssl, auth=self.auth)
         if request.status_code == 200:
             return request.json()
         else:
@@ -1186,7 +1187,7 @@ class Gitlab(object):
         data = {'merge_commit_message': merge_commit_message}
 
         request = requests.put('{0}/{1}/merge_request/{2}/merge'.format(self.projects_url, project_id, mergerequest_id),
-                               data=data, headers=self.headers, verify=self.verify_ssl)
+                               data=data, headers=self.headers, verify=self.verify_ssl, auth=self.auth)
         if request.status_code == 200:
             return request.json()
         else:
@@ -1202,7 +1203,7 @@ class Gitlab(object):
         """
         request = requests.post(
             '{0}/{1}/merge_request/{2}/comments'.format(self.projects_url, project_id, mergerequest_id),
-            data={'note': note}, headers=self.headers, verify=self.verify_ssl)
+            data={'note': note}, headers=self.headers, verify=self.verify_ssl, auth=self.auth)
 
         return request.status_code == 201
 
@@ -1214,7 +1215,7 @@ class Gitlab(object):
         """
         data = {'page': page, 'per_page': per_page}
         request = requests.get("{0}/{1}/snippets".format(self.projects_url, project_id), params=data,
-                               verify=self.verify_ssl, headers=self.headers)
+                               verify=self.verify_ssl, auth=self.auth, headers=self.headers)
         if request.status_code == 200:
             return request.json()
         else:
@@ -1228,7 +1229,7 @@ class Gitlab(object):
         :return: dictionary
         """
         request = requests.get("{0}/{1}/snippets/{2}".format(self.projects_url, project_id, snippet_id),
-                               verify=self.verify_ssl, headers=self.headers)
+                               verify=self.verify_ssl, auth=self.auth, headers=self.headers)
         if request.status_code == 200:
             return request.json()
         else:
@@ -1248,7 +1249,7 @@ class Gitlab(object):
         if lifetime != "":
             data["lifetime"] = lifetime
         request = requests.post("{0}/{1}/snippets".format(self.projects_url, project_id),
-                                data=data, verify=self.verify_ssl, headers=self.headers)
+                                data=data, verify=self.verify_ssl, auth=self.auth, headers=self.headers)
         if request.status_code == 201:
             return request.json()
         else:
@@ -1262,7 +1263,7 @@ class Gitlab(object):
         :return: the content of the snippet
         """
         request = requests.get("{0}/{1}/snippets/{2}/raw".format(self.projects_url, project_id, snippet_id),
-                               verify=self.verify_ssl, headers=self.headers)
+                               verify=self.verify_ssl, auth=self.auth, headers=self.headers)
         if request.status_code == 200:
             return request.json()
         else:
@@ -1276,7 +1277,7 @@ class Gitlab(object):
         :return: True if success
         """
         request = requests.delete("{0}/{1}/snippets/{2}".format(self.projects_url, project_id, snippet_id),
-                                  headers=self.headers, verify=self.verify_ssl)
+                                  headers=self.headers, verify=self.verify_ssl, auth=self.auth)
         return request.status_code == 200
 
     def getrepositories(self, project_id, page=1, per_page=20):
@@ -1287,7 +1288,7 @@ class Gitlab(object):
         """
         data = {'page': page, 'per_page': per_page}
         request = requests.get("{0}/{1}/repository/branches".format(self.projects_url, project_id), params=data,
-                               verify=self.verify_ssl, headers=self.headers)
+                               verify=self.verify_ssl, auth=self.auth, headers=self.headers)
         if request.status_code == 200:
             return request.json()
         else:
@@ -1301,7 +1302,7 @@ class Gitlab(object):
         :return: dict of the branch
         """
         request = requests.get("{0}/{1}/repository/branches/{2}".format(self.projects_url, project_id, branch),
-                               verify=self.verify_ssl, headers=self.headers)
+                               verify=self.verify_ssl, auth=self.auth, headers=self.headers)
         if request.status_code == 200:
             return request.json()
         elif request.status_code == 404:
@@ -1320,7 +1321,7 @@ class Gitlab(object):
         :return: dict with the branch
         """
         request = requests.put("{0}/{1}/repository/branches/{2}/protect".format(self.projects_url, project_id, branch),
-                               headers=self.headers, verify=self.verify_ssl)
+                               headers=self.headers, verify=self.verify_ssl, auth=self.auth)
         if request.status_code == 200:
             return request.json()
         else:
@@ -1335,7 +1336,7 @@ class Gitlab(object):
         :return: dict with the branch
         """
         request = requests.put("{0}/{1}/repository/branches/{2}/unprotect".format(self.projects_url, project_id, branch),
-                               headers=self.headers, verify=self.verify_ssl)
+                               headers=self.headers, verify=self.verify_ssl, auth=self.auth)
         if request.status_code == 200:
             return request.json()
         else:
@@ -1349,7 +1350,7 @@ class Gitlab(object):
         """
         data = {'page': page, 'per_page': per_page}
         request = requests.get("{0}/{1}/repository/tags".format(self.projects_url, project_id), params=data,
-                               verify=self.verify_ssl, headers=self.headers)
+                               verify=self.verify_ssl, auth=self.auth, headers=self.headers)
         if request.status_code == 200:
             return request.json()
         else:
@@ -1367,7 +1368,7 @@ class Gitlab(object):
 
         data = {"id": project_id, "tag_name": tag_name, "ref": ref, "message": message}
         request = requests.post("{0}/{1}/repository/tags".format(self.projects_url, project_id), data=data,
-                                verify=self.verify_ssl, headers=self.headers)
+                                verify=self.verify_ssl, auth=self.auth, headers=self.headers)
 
         if request.status_code == 201:
             return request.json()
@@ -1385,7 +1386,7 @@ class Gitlab(object):
         if ref_name is not None:
             data.update({"ref_name": ref_name})
         request = requests.get("{0}/{1}/repository/commits".format(self.projects_url, project_id),
-                               verify=self.verify_ssl, params=data, headers=self.headers)
+                               verify=self.verify_ssl, auth=self.auth, params=data, headers=self.headers)
         if request.status_code == 200:
             return request.json()
         else:
@@ -1399,7 +1400,7 @@ class Gitlab(object):
         :return: dic tof commit
         """
         request = requests.get("{0}/{1}/repository/commits/{2}".format(self.projects_url, project_id, sha1),
-                               verify=self.verify_ssl, headers=self.headers)
+                               verify=self.verify_ssl, auth=self.auth, headers=self.headers)
         if request.status_code == 200:
             return request.json()
         else:
@@ -1413,7 +1414,7 @@ class Gitlab(object):
         :return: dict with the diff
         """
         request = requests.get("{0}/{1}/repository/commits/{2}/diff".format(self.projects_url, project_id, sha1),
-                               verify=self.verify_ssl, headers=self.headers)
+                               verify=self.verify_ssl, auth=self.auth, headers=self.headers)
         if request.status_code == 200:
             return request.json()
         else:
@@ -1432,7 +1433,7 @@ class Gitlab(object):
             data.update(kwargs)
 
         request = requests.get("{0}/{1}/repository/tree".format(self.projects_url, project_id), params=data,
-                               verify=self.verify_ssl, headers=self.headers)
+                               verify=self.verify_ssl, auth=self.auth, headers=self.headers)
         if request.status_code == 200:
             return request.json()
         else:
@@ -1448,7 +1449,7 @@ class Gitlab(object):
         """
         data = {"filepath": filepath}
         request = requests.get("{0}/{1}/repository/blobs/{2}".format(self.projects_url, project_id, sha1),
-                               params=data, verify=self.verify_ssl,
+                               params=data, verify=self.verify_ssl, auth=self.auth,
                                headers=self.headers)
         if request.status_code == 200:
             return request.content
@@ -1463,7 +1464,7 @@ class Gitlab(object):
         :return: raw blob
         """
         request = requests.get("{0}/{1}/repository/raw_blobs/{2}".format(self.projects_url, project_id, sha1),
-                               verify=self.verify_ssl, headers=self.headers)
+                               verify=self.verify_ssl, auth=self.auth, headers=self.headers)
         if request.status_code == 200:
             return request.content
         else:
@@ -1477,7 +1478,7 @@ class Gitlab(object):
         """
         data = {'page': page, 'per_page': per_page}
         request = requests.get("{0}/{1}/repository/contributors".format(self.projects_url, project_id), params=data,
-                               verify=self.verify_ssl, headers=self.headers)
+                               verify=self.verify_ssl, auth=self.auth, headers=self.headers)
         if request.status_code == 200:
             return request.json()
         else:
@@ -1493,7 +1494,7 @@ class Gitlab(object):
         """
         data = {"from": from_id, "to": to_id}
         request = requests.get("{0}/{1}/repository/compare".format(self.projects_url, project_id),
-                               params=data, verify=self.verify_ssl,
+                               params=data, verify=self.verify_ssl, auth=self.auth,
                                headers=self.headers)
 
         if request.status_code == 200:
@@ -1509,7 +1510,7 @@ class Gitlab(object):
         """
         data = {'page': page, 'per_page': per_page}
         request = requests.get("{0}/{1}".format(self.search_url, search), params=data,
-                               verify=self.verify_ssl, headers=self.headers)
+                               verify=self.verify_ssl, auth=self.auth, headers=self.headers)
 
         if request.status_code == 200:
             return request.json()
@@ -1524,7 +1525,7 @@ class Gitlab(object):
         :return: True if the file was saved to the filepath
         """
         request = requests.get("{0}/{1}/repository/archive".format(self.projects_url, project_id),
-                               verify=self.verify_ssl, headers=self.headers)
+                               verify=self.verify_ssl, auth=self.auth, headers=self.headers)
         if request.status_code == 200:
             if filepath == "":
                 filepath = request.headers['content-disposition'].split(";")[1].split("=")[1].strip('"')
@@ -1544,7 +1545,7 @@ class Gitlab(object):
         :return: True if it deleted, False if it couldn't. False could happen for several reasons, but there isn't a good way of differentiating them
         """
         request = requests.delete("{0}/{1}".format(self.groups_url, group_id),
-                                  headers=self.headers, verify=self.verify_ssl)
+                                  headers=self.headers, verify=self.verify_ssl, auth=self.auth)
         return request.status_code == 200
 
     def getgroupmembers(self, group_id, page=1, per_page=20):
@@ -1557,7 +1558,7 @@ class Gitlab(object):
         """
         data = {'page': page, 'per_page': per_page}
         request = requests.get("{0}/{1}/members".format(self.groups_url, group_id), params=data,
-                               headers=self.headers, verify=self.verify_ssl)
+                               headers=self.headers, verify=self.verify_ssl, auth=self.auth)
         if request.status_code == 200:
             return request.json()
         else:
@@ -1587,7 +1588,7 @@ class Gitlab(object):
         data = {"id": group_id, "user_id": user_id, "access_level": access_level}
 
         request = requests.post("{0}/{1}/members".format(self.groups_url, group_id),
-                                headers=self.headers, data=data, verify=self.verify_ssl)
+                                headers=self.headers, data=data, verify=self.verify_ssl, auth=self.auth)
         return request.status_code == 201
 
     def editgroupmember(self, group_id, user_id, access_level):
@@ -1615,7 +1616,7 @@ class Gitlab(object):
         data = {"id": group_id, "user_id": user_id, "access_level": access_level}
 
         request = requests.put("{0}/{1}/members/{2}".format(self.groups_url, group_id, user_id),
-                                headers=self.headers, data=data, verify=self.verify_ssl)
+                                headers=self.headers, data=data, verify=self.verify_ssl, auth=self.auth)
         return request.status_code == 200
 
     def deletegroupmember(self, group_id, user_id):
@@ -1626,7 +1627,7 @@ class Gitlab(object):
         :return: always true
         """
         request = requests.delete("{0}/{1}/members/{2}".format(self.groups_url, group_id, user_id),
-                                  headers=self.headers, verify=self.verify_ssl)
+                                  headers=self.headers, verify=self.verify_ssl, auth=self.auth)
         if request.status_code == 200:
             return True  # It always returns true
 
@@ -1636,7 +1637,7 @@ class Gitlab(object):
         """
         data = {'page': page, 'per_page': per_page}
         request = requests.get("{0}/{1}/issues/{2}/notes".format(self.projects_url, project_id, issue_id), params=data,
-                               verify=self.verify_ssl, headers=self.headers)
+                               verify=self.verify_ssl, auth=self.auth, headers=self.headers)
 
         if request.status_code == 200:
             return request.json()
@@ -1648,7 +1649,7 @@ class Gitlab(object):
 
         """
         request = requests.get("{0}/{1}/issues/{2}/notes/{3}".format(self.projects_url, project_id, issue_id, note_id),
-                               verify=self.verify_ssl, headers=self.headers)
+                               verify=self.verify_ssl, auth=self.auth, headers=self.headers)
 
         if request.status_code == 200:
             return request.json()
@@ -1661,7 +1662,7 @@ class Gitlab(object):
         """
         data = {"body": content}
         request = requests.post("{0}/{1}/issues/{2}/notes".format(self.projects_url, project_id, issue_id),
-                                verify=self.verify_ssl, headers=self.headers, data=data)
+                                verify=self.verify_ssl, auth=self.auth, headers=self.headers, data=data)
 
         if request.status_code == 201:
             return request.json()
@@ -1674,7 +1675,7 @@ class Gitlab(object):
         """
         data = {'page': page, 'per_page': per_page}
         request = requests.get("{0}/{1}/snippets/{2}/notes".format(self.projects_url, project_id, snippet_id),
-                               params=data, verify=self.verify_ssl, headers=self.headers)
+                               params=data, verify=self.verify_ssl, auth=self.auth, headers=self.headers)
 
         if request.status_code == 200:
             return request.json()
@@ -1686,7 +1687,7 @@ class Gitlab(object):
 
         """
         request = requests.get("{0}/{1}/snippets/{2}/notes/{3}".format(self.projects_url, project_id, snippet_id, note_id),
-                               verify=self.verify_ssl, headers=self.headers)
+                               verify=self.verify_ssl, auth=self.auth, headers=self.headers)
 
         if request.status_code == 200:
             return request.json()
@@ -1699,7 +1700,7 @@ class Gitlab(object):
         """
         data = {"body": content}
         request = requests.post("{0}/{1}/snippets/{2}/notes".format(self.projects_url, project_id, snippet_id),
-                                verify=self.verify_ssl, headers=self.headers, data=data)
+                                verify=self.verify_ssl, auth=self.auth, headers=self.headers, data=data)
 
         if request.status_code == 201:
             return request.json()
@@ -1712,7 +1713,7 @@ class Gitlab(object):
         """
         data = {'page': page, 'per_page': per_page}
         request = requests.get("{0}/{1}/merge_requests/{2}/notes".format(self.projects_url, project_id, merge_request_id),
-                               params=data, verify=self.verify_ssl, headers=self.headers)
+                               params=data, verify=self.verify_ssl, auth=self.auth, headers=self.headers)
 
         if request.status_code == 200:
             return request.json()
@@ -1725,7 +1726,7 @@ class Gitlab(object):
         """
         request = requests.get("{0}/{1}/merge_requests/{2}/notes/{3}".format(self.projects_url, project_id,
                                                                          merge_request_id, note_id),
-                               verify=self.verify_ssl, headers=self.headers)
+                               verify=self.verify_ssl, auth=self.auth, headers=self.headers)
 
         if request.status_code == 200:
             return request.json()
@@ -1738,7 +1739,7 @@ class Gitlab(object):
         """
         data = {"body": content}
         request = requests.post("{0}/{1}/merge_requests/{2}/notes".format(self.projects_url, project_id, merge_request_id),
-                                verify=self.verify_ssl, headers=self.headers, data=data)
+                                verify=self.verify_ssl, auth=self.auth, headers=self.headers, data=data)
 
         if request.status_code == 201:
             return request.json()
@@ -1758,7 +1759,7 @@ class Gitlab(object):
         data = {"file_path": file_path, "branch_name": branch_name,
                 "content": content, "commit_message": commit_message}
         request = requests.post("{0}/{1}/repository/files".format(self.projects_url, project_id),
-                                verify=self.verify_ssl, headers=self.headers, data=data)
+                                verify=self.verify_ssl, auth=self.auth, headers=self.headers, data=data)
         return request.status_code == 201
 
     def updatefile(self, project_id, file_path, branch_name, content, commit_message):
@@ -1774,7 +1775,7 @@ class Gitlab(object):
         data = {"file_path": file_path, "branch_name": branch_name,
                 "content": content, "commit_message": commit_message}
         request = requests.put("{0}/{1}/repository/files".format(self.projects_url, project_id),
-                               headers=self.headers, data=data, verify=self.verify_ssl)
+                               headers=self.headers, data=data, verify=self.verify_ssl, auth=self.auth)
 
         return request.status_code == 200
 
@@ -1789,7 +1790,7 @@ class Gitlab(object):
         """
         data = {"file_path": file_path, "ref": ref}
         request = requests.get("{0}/{1}/repository/files".format(self.projects_url, project_id),
-                               headers=self.headers, data=data, verify=self.verify_ssl)
+                               headers=self.headers, data=data, verify=self.verify_ssl, auth=self.auth)
         if request.status_code == 200:
             return request.json()
         else:
@@ -1808,7 +1809,7 @@ class Gitlab(object):
                 "commit_message": commit_message}
         request = requests.delete("{0}/{1}/repository/files".format(self.projects_url, project_id),
                                   headers=self.headers, data=data,
-                                  verify=self.verify_ssl)
+                                  verify=self.verify_ssl, auth=self.auth)
         return request.status_code == 200
 
     def setgitlabciservice(self, project_id, token, project_url):
@@ -1821,7 +1822,7 @@ class Gitlab(object):
         """
         data = {"token": token, "project_url": project_url}
         request = requests.put("{0}/{1}/services/gitlab-ci".format(self.projects_url, project_id),
-                               verify=self.verify_ssl, headers=self.headers, data=data)
+                               verify=self.verify_ssl, auth=self.auth, headers=self.headers, data=data)
 
         return request.status_code == 200
 
@@ -1831,7 +1832,7 @@ class Gitlab(object):
         :return: true if success, false if not
         """
         request = requests.delete("{0}/{1}/services/gitlab-ci".format(self.projects_url, project_id),
-                                  headers=self.headers, verify=self.verify_ssl)
+                                  headers=self.headers, verify=self.verify_ssl, auth=self.auth)
 
         return request.status_code == 200
 
@@ -1842,7 +1843,7 @@ class Gitlab(object):
         :return: list of the labels
         """
         request = requests.get("{0}/{1}/labels".format(self.projects_url, project_id),
-                               verify=self.verify_ssl, headers=self.headers)
+                               verify=self.verify_ssl, auth=self.auth, headers=self.headers)
 
         if request.status_code == 200:
             return request.json()
@@ -1860,7 +1861,7 @@ class Gitlab(object):
 
         data = {"name": name, "color": color}
         request = requests.post("{0}/{1}/labels".format(self.projects_url, project_id), data=data,
-                                verify=self.verify_ssl, headers=self.headers)
+                                verify=self.verify_ssl, auth=self.auth, headers=self.headers)
         if request.status_code == 201:
             return request.json()
         else:
@@ -1876,7 +1877,7 @@ class Gitlab(object):
         data = {"name": name}
 
         request = requests.delete("{0}/{1}/labels".format(self.projects_url, project_id), data=data,
-                                  verify=self.verify_ssl, headers=self.headers)
+                                  verify=self.verify_ssl, auth=self.auth, headers=self.headers)
 
         return request.status_code == 200
 
@@ -1890,7 +1891,7 @@ class Gitlab(object):
         data = {"name": name, "new_name": new_name, "color": color}
 
         request = requests.put("{0}/{1}/labels".format(self.projects_url, project_id), data=data,
-                               verify=self.verify_ssl, headers=self.headers)
+                               verify=self.verify_ssl, auth=self.auth, headers=self.headers)
 
         if request.status_code == 200:
             return request.json()


### PR DESCRIPTION
Hi,
my setup made it necessary, to have the possibility to pass authentication credentials to the underlying requests library. This is because our Gitlab instance is protected by an additional HTTP authentication.

With the proposed merge request, users can pass the tupel auth=(username, password) to the gitlab constructor. It will then be used in every http request performed by the api. If left empty 'auth' will be set to 'None' and have no effect on the request.

``` python
def __init__(self, host, token="", oauth_token="", verify_ssl=True, auth=None):
```

As my additions to the code might be useful for others as well, I offer to merge them into your upstream repo.

cbandera
