### PR TITLE
Added build_events to project hook APIs

### DIFF
--- a/gitlab/__init__.py
+++ b/gitlab/__init__.py
@@ -586,7 +586,7 @@ class Gitlab(object):
         else:
             return False
 
-    def addprojecthook(self, project_id, url, push=False, issues=False, merge_requests=False, tag_push=False):
+    def addprojecthook(self, project_id, url, push=False, issues=False, merge_requests=False, tag_push=False, build=False):
         """
         add a hook to a project
         :param id_: project id
@@ -598,6 +598,7 @@ class Gitlab(object):
         data['issues_events'] = int(bool(issues))
         data['merge_requests_events'] = int(bool(merge_requests))
         data['tag_push_events'] = int(bool(tag_push))
+        data['build_events'] = int(bool(build))
         request = requests.post("{0}/{1}/hooks".format(self.projects_url, project_id),
                                 headers=self.headers, data=data, verify=self.verify_ssl, auth=self.auth, timeout=self.timeout)
         if request.status_code == 201:
@@ -606,7 +607,7 @@ class Gitlab(object):
             return False
 
     def editprojecthook(self, project_id, hook_id, url, push=False,
-            issues=False, merge_requests=False, tag_push=False):
+            issues=False, merge_requests=False, tag_push=False, build=False):
         """
         edit an existing hook from a project
         :param id_: project id
@@ -619,6 +620,7 @@ class Gitlab(object):
         data['issues_events'] = int(bool(issues))
         data['merge_requests_events'] = int(bool(merge_requests))
         data['tag_push_events'] = int(bool(tag_push))
+        data['build_events'] = int(bool(build))
         request = requests.put("{0}/{1}/hooks/{2}".format(self.projects_url, project_id, hook_id),
                                headers=self.headers, data=data, verify=self.verify_ssl, auth=self.auth, timeout=self.timeout)
         if request.status_code == 200:


### PR DESCRIPTION
Added `build_events` argument to `addprojecthook` and `editprojecthook` methods since now they both have `build_events` argument in the Gitlab API.
