### PR TITLE
refactor: Use `raise_for_status()`

### DIFF
--- a/gitlab/__init__.py
+++ b/gitlab/__init__.py
@@ -147,12 +147,12 @@ class Gitlab(object):
         :returns bool: :obj:`False` on failure when exceptions are suppressed
         :raises requests.exceptions.HTTPError: If invalid response returned
         """
+        if self.suppress_http_error and not response.ok:
+            return False
+
         response_json = default_response
         if response_json is None:
             response_json = {}
-
-        if self.suppress_http_error and not response.ok:
-            return False
 
         response.raise_for_status()
 

--- a/gitlab/__init__.py
+++ b/gitlab/__init__.py
@@ -137,19 +137,22 @@ class Gitlab(object):
             return quote_plus(string)
         return string
 
-    @staticmethod
-    def success_or_raise(response, default_response=None):
+    def success_or_raise(self, response, default_response=None):
         """
         Check if request was successful or raises an HttpError
 
         :param response: Response Object to check
         :param default_response: Return value if JSONDecodeError
-        :return: Dictionary containing response data
+        :returns dict: Dictionary containing response data
+        :returns bool: :obj:`False` on failure when exceptions are suppressed
         :raises requests.exceptions.HTTPError: If invalid response returned
         """
         response_json = default_response or {}
 
-        response.raise_for_status()
+        if self.suppress_http_error and not response.ok:
+            response_json = False
+        else:
+            response.raise_for_status()
 
         try:
             response_json = response.json()

--- a/gitlab/__init__.py
+++ b/gitlab/__init__.py
@@ -648,10 +648,7 @@ class Gitlab(object):
         :param project_id: project id
         :return: always true
         """
-        try:
-            self.delete_project(project_id)
-        except exceptions.HttpError:
-            pass
+        self.delete_project(project_id)
         return True
 
     def createprojectuser(self, user_id, name, **kwargs):

--- a/gitlab/__init__.py
+++ b/gitlab/__init__.py
@@ -152,24 +152,18 @@ class Gitlab(object):
         :param status_codes: List of Ints, Valid status codes to check for
         :param default_response: Return value if JSONDecodeError
         :return: Dictionary containing response data
-        :raise: HttpError: If invalid response returned
+        :raises requests.exceptions.HTTPError: If invalid response returned
         """
-        if default_response is None:
-            default_response = {}
+        response_json = default_response or {}
 
-        if response.status_code in status_codes:
-            try:
-                return response.json()
-            except JSONDecodeError:
-                return default_response
+        response.raise_for_status()
 
-        raise exceptions.HttpError(
-            ('Something went wrong, '
-             'status code: {status_code}, '
-             'text response: {json}').format(
-                 status_code=response.status_code,
-                 json=response.text)
-            )
+        try:
+            response_json = response.json()
+        except JSONDecodeError:
+            pass
+
+        return response_json
 
     def login(self, email=None, password=None, user=None):
         """

--- a/gitlab/__init__.py
+++ b/gitlab/__init__.py
@@ -77,7 +77,7 @@ class Gitlab(object):
                                 verify=self.verify_ssl, auth=self.auth,
                                 timeout=self.timeout)
 
-        return self.success_or_raise(response, [200], default_response=default_response)
+        return self.success_or_raise(response, default_response=default_response)
 
     def post(self, uri, default_response=None, **kwargs):
         """
@@ -105,7 +105,7 @@ class Gitlab(object):
             url, headers=self.headers, data=kwargs,
             verify=self.verify_ssl, auth=self.auth, timeout=self.timeout)
 
-        return self.success_or_raise(response, [201], default_response=default_response)
+        return self.success_or_raise(response, default_response=default_response)
 
     def delete(self, uri, default_response=None):
         """
@@ -128,8 +128,7 @@ class Gitlab(object):
             url, headers=self.headers, verify=self.verify_ssl,
             auth=self.auth, timeout=self.timeout)
 
-        return self.success_or_raise(
-            response, [204, 200], default_response=default_response)
+        return self.success_or_raise(response, default_response=default_response)
 
     @staticmethod
     def _format_string(string):
@@ -144,12 +143,11 @@ class Gitlab(object):
         return string
 
     @staticmethod
-    def success_or_raise(response, status_codes, default_response=None):
+    def success_or_raise(response, default_response=None):
         """
         Check if request was successful or raises an HttpError
 
         :param response: Response Object to check
-        :param status_codes: List of Ints, Valid status codes to check for
         :param default_response: Return value if JSONDecodeError
         :return: Dictionary containing response data
         :raises requests.exceptions.HTTPError: If invalid response returned

--- a/gitlab/__init__.py
+++ b/gitlab/__init__.py
@@ -298,10 +298,10 @@ class Gitlab(object):
         """
         deleted = self.delete_user(user_id)
 
-        if deleted:
-            return True
-        else:
+        if deleted is False:
             return False
+        else:
+            return True
 
     def currentuser(self):
         """

--- a/gitlab/__init__.py
+++ b/gitlab/__init__.py
@@ -514,10 +514,7 @@ class Gitlab(object):
         :param project_id: id or namespace/project_name of the project
         :return: False if not found, a dictionary if found
         """
-        try:
-            return self.get_project(project_id)
-        except exceptions.HttpError:
-            return False
+        return self.get_project(project_id)
 
     def getprojectevents(self, project_id, page=1, per_page=20):
         """

--- a/gitlab/__init__.py
+++ b/gitlab/__init__.py
@@ -296,10 +296,11 @@ class Gitlab(object):
         :param user_id: The ID of the user
         :return: True if it deleted, False if it couldn't
         """
-        try:
-            self.delete_user(user_id)
+        deleted = self.delete_user(user_id)
+
+        if deleted:
             return True
-        except exceptions.HttpError:
+        else:
             return False
 
     def currentuser(self):

--- a/gitlab/__init__.py
+++ b/gitlab/__init__.py
@@ -150,9 +150,9 @@ class Gitlab(object):
         response_json = default_response or {}
 
         if self.suppress_http_error and not response.ok:
-            response_json = False
-        else:
-            response.raise_for_status()
+            return False
+
+        response.raise_for_status()
 
         try:
             response_json = response.json()

--- a/gitlab/__init__.py
+++ b/gitlab/__init__.py
@@ -228,10 +228,7 @@ class Gitlab(object):
         :param per_page: Number of items to list per page (default: 20, max: 100)
         :return: returns a dictionary of the users, false if there is an error
         """
-        try:
-            return self.get_users(search=search, page=page, per_page=per_page, **kwargs)
-        except exceptions.HttpError:
-            return False
+        return self.get_users(search=search, page=page, per_page=per_page, **kwargs)
 
     def getuser(self, user_id):
         """

--- a/gitlab/__init__.py
+++ b/gitlab/__init__.py
@@ -17,13 +17,17 @@ class Gitlab(object):
     """
     Gitlab class
     """
-    def __init__(self, host, token="", oauth_token="", verify_ssl=True, auth=None, timeout=None):
+    def __init__(self, host, token="", oauth_token="", verify_ssl=True, auth=None, timeout=None, suppress_http_error=True):
         """
         On init we setup the token used for all the api calls and all the urls
 
         :param host: host of gitlab
         :param token: token
+        :param suppress_http_error: Use :obj:`False` to unsuppress
+            :class:`requests.exceptions.HTTPError` exceptions on failure
         """
+        self.suppress_http_error = suppress_http_error
+
         if token is not '':
             self.token = token
             self.headers = {'PRIVATE-TOKEN': self.token}

--- a/gitlab/__init__.py
+++ b/gitlab/__init__.py
@@ -69,9 +69,6 @@ class Gitlab(object):
         :return: Dictionary containing response data
         :raise: HttpError: If invalid response returned
         """
-        if default_response is None:
-            default_response = {}
-
         url = self.api_url + uri
         response = requests.get(url, params=kwargs, headers=self.headers,
                                 verify=self.verify_ssl, auth=self.auth,
@@ -96,9 +93,6 @@ class Gitlab(object):
         :return: Dictionary containing response data
         :raise: HttpError: If invalid response returned
         """
-        if default_response is None:
-            default_response = {}
-
         url = self.api_url + uri
 
         response = requests.post(
@@ -120,9 +114,6 @@ class Gitlab(object):
         :return: Dictionary containing response data
         :raise: HttpError: If invalid response returned
         """
-        if default_response is None:
-            default_response = {}
-
         url = self.api_url + uri
         response = requests.delete(
             url, headers=self.headers, verify=self.verify_ssl,

--- a/gitlab/__init__.py
+++ b/gitlab/__init__.py
@@ -147,7 +147,9 @@ class Gitlab(object):
         :returns bool: :obj:`False` on failure when exceptions are suppressed
         :raises requests.exceptions.HTTPError: If invalid response returned
         """
-        response_json = default_response or {}
+        response_json = default_response
+        if response_json is None:
+            response_json = {}
 
         if self.suppress_http_error and not response.ok:
             return False

--- a/gitlab_tests/test_v91/test_deploy_keys.py
+++ b/gitlab_tests/test_v91/test_deploy_keys.py
@@ -1,6 +1,6 @@
 import responses
+from requests.exceptions import HTTPError
 
-from gitlab.exceptions import HttpError
 from gitlab_tests.base import BaseTest
 from response_data.deploy_keys import *
 
@@ -37,7 +37,9 @@ class TestGetAllDeployKeys(BaseTest):
             status=404,
             content_type='application/json')
 
-        self.assertRaises(HttpError, self.gitlab.get_all_deploy_keys)
+        self.gitlab.suppress_http_error = False
+        self.assertRaises(HTTPError, self.gitlab.get_all_deploy_keys)
+        self.gitlab.suppress_http_error = True
 
 
 class TestEnableDeployKeys(BaseTest):
@@ -61,4 +63,6 @@ class TestEnableDeployKeys(BaseTest):
             status=500,
             content_type='application/json')
 
-        self.assertRaises(HttpError, self.gitlab.enable_deploy_key, 5, 2)
+        self.gitlab.suppress_http_error = False
+        self.assertRaises(HTTPError, self.gitlab.enable_deploy_key, 5, 2)
+        self.gitlab.suppress_http_error = True

--- a/gitlab_tests/test_v91/test_projects.py
+++ b/gitlab_tests/test_v91/test_projects.py
@@ -1,6 +1,6 @@
 import responses
+from requests.exceptions import HTTPError
 
-from gitlab.exceptions import HttpError
 from gitlab_tests.base import BaseTest
 from response_data.projects import *
 
@@ -39,7 +39,9 @@ class TestDeleteProject(BaseTest):
             status=404,
             content_type='application/json')
 
-        self.assertRaises(HttpError, self.gitlab.delete_project, 1)
+        self.gitlab.suppress_http_error = False
+        self.assertRaises(HTTPError, self.gitlab.delete_project, 1)
+        self.gitlab.suppress_http_error = True
         self.assertEqual(True, self.gitlab.deleteproject(1))
 
 
@@ -65,5 +67,7 @@ class TestGetProject(BaseTest):
             status=404,
             content_type='application/json')
 
-        self.assertRaises(HttpError, self.gitlab.get_project, 1)
+        self.gitlab.suppress_http_error = False
+        self.assertRaises(HTTPError, self.gitlab.get_project, 1)
+        self.gitlab.suppress_http_error = True
         self.assertFalse(self.gitlab.getproject(1))

--- a/gitlab_tests/test_v91/test_tags.py
+++ b/gitlab_tests/test_v91/test_tags.py
@@ -1,6 +1,6 @@
 import responses
+from requests.exceptions import HTTPError
 
-from gitlab.exceptions import HttpError
 from gitlab_tests.base import BaseTest
 from response_data.tags import *
 
@@ -26,4 +26,6 @@ class TestDeleteRepositoryTag(BaseTest):
             status=404,
             content_type='application/json')
 
-        self.assertRaises(HttpError, self.gitlab.delete_repository_tag, 5, 'test')
+        self.gitlab.suppress_http_error = False
+        self.assertRaises(HTTPError, self.gitlab.delete_repository_tag, 5, 'test')
+        self.gitlab.suppress_http_error = True

--- a/gitlab_tests/test_v91/test_users.py
+++ b/gitlab_tests/test_v91/test_users.py
@@ -2,9 +2,9 @@ import os
 from unittest import TestCase
 
 import responses
+from requests.exceptions import HTTPError
 
 from gitlab import Gitlab
-from gitlab.exceptions import HttpError
 from gitlab_tests.base import BaseTest
 from response_data.users import *
 
@@ -34,7 +34,9 @@ class TestGetUsers(BaseTest):
             status=404,
             content_type='application/json')
 
-        self.assertRaises(HttpError, self.gitlab.get_users)
+        self.gitlab.suppress_http_error = False
+        self.assertRaises(HTTPError, self.gitlab.get_users)
+        self.gitlab.suppress_http_error = True
         self.assertEqual(False, self.gitlab.getusers())
 
 
@@ -60,5 +62,7 @@ class TestDeleteUser(BaseTest):
             status=404,
             content_type='application/json')
 
-        self.assertRaises(HttpError, self.gitlab.delete_user, 14)
+        self.gitlab.suppress_http_error = False
+        self.assertRaises(HTTPError, self.gitlab.delete_user, 14)
+        self.gitlab.suppress_http_error = True
         self.assertFalse(self.gitlab.deleteuser(14))


### PR DESCRIPTION
Refactored code to rely on `requests.models.Response.raise_for_status()` to raise `requests.exceptions.HTTPError`. Also implemented a class attribute `suppress_http_error` so we default to the legacy behaviour of `return False`.

See also: #193